### PR TITLE
Feature/issue 65 performance improvements

### DIFF
--- a/src/renderer/MeshRenderer.js
+++ b/src/renderer/MeshRenderer.js
@@ -21,6 +21,11 @@ export default class MeshRenderer extends BaseRenderer {
       new THREE.BoxGeometry(50, 50, 50),
       new THREE.MeshLambertMaterial({ color: '#ff0000' })
     );
+    this.ThreeSprite = THREE.Sprite;
+  }
+
+  isThreeSprite(particle) {
+    return particle.target instanceof this.ThreeSprite;
   }
 
   onSystemUpdate() {}
@@ -47,23 +52,27 @@ export default class MeshRenderer extends BaseRenderer {
   }
 
   onParticleUpdate(particle) {
-    if (particle.target) {
-      particle.target.position.copy(particle.position);
-      particle.target.rotation.set(
-        particle.rotation.x,
-        particle.rotation.y,
-        particle.rotation.z
-      );
-      this.scale(particle);
+    const { target, useAlpha, useColor, rotation } = particle;
 
-      if (particle.useAlpha) {
-        particle.target.material.opacity = particle.alpha;
-        particle.target.material.transparent = true;
-      }
+    if (!target) {
+      return;
+    }
 
-      if (particle.useColor) {
-        particle.target.material.color.copy(particle.color);
-      }
+    target.position.copy(particle.position);
+
+    if (!this.isThreeSprite(particle)) {
+      target.rotation.set(rotation.x, rotation.y, rotation.z);
+    }
+
+    this.scale(particle);
+
+    if (useAlpha) {
+      target.material.opacity = particle.alpha;
+      target.material.transparent = true;
+    }
+
+    if (useColor) {
+      target.material.color.copy(particle.color);
     }
   }
 

--- a/src/renderer/MeshRenderer.js
+++ b/src/renderer/MeshRenderer.js
@@ -21,11 +21,10 @@ export default class MeshRenderer extends BaseRenderer {
       new THREE.BoxGeometry(50, 50, 50),
       new THREE.MeshLambertMaterial({ color: '#ff0000' })
     );
-    this.ThreeSprite = THREE.Sprite;
   }
 
   isThreeSprite(particle) {
-    return particle.target instanceof this.ThreeSprite;
+    return particle.target.isSprite;
   }
 
   onSystemUpdate() {}

--- a/src/utils/PUID.js
+++ b/src/utils/PUID.js
@@ -5,15 +5,13 @@ export default {
     return `PUID_${this._id++}`;
   },
   id: function(functionOrObject) {
-    for (let id in this._uids) {
-      if (this._uids[id] == functionOrObject) {
-        return id;
-      }
+    if (this._uids.has(functionOrObject)) {
+      return this._uids.get(functionOrObject);
     }
 
     const newId = this.getNewId();
 
-    this._uids[newId] = functionOrObject;
+    this._uids.set(functionOrObject, newId);
 
     return newId;
   },

--- a/src/utils/PUID.js
+++ b/src/utils/PUID.js
@@ -1,6 +1,6 @@
 export default {
   _id: 0,
-  _uids: {},
+  _uids: new Map(),
   getNewId: function() {
     return `PUID_${this._id++}`;
   },

--- a/test/renderer/MeshRenderer.spec.js
+++ b/test/renderer/MeshRenderer.spec.js
@@ -123,6 +123,29 @@ describe('renderer -> MeshRenderer', () => {
       assert(scaleSpy.calledOnceWith(particle));
     });
 
+    it('should not set target rotation if the target is a THREE Sprite', () => {
+      const container = new THREE.Scene();
+      const particle = new Particle();
+      const renderer = new MeshRenderer(container, THREE);
+
+      particle.body = new THREE.Sprite(
+        new THREE.SpriteMaterial({
+          color: 0xff0000,
+          blending: THREE.AdditiveBlending,
+          fog: true,
+        })
+      );
+
+      // Ensure the particle has a target
+      renderer.onParticleCreated(particle);
+
+      const targetRotationSetSpy = spy(particle.target.rotation, 'set');
+
+      renderer.onParticleUpdate(particle);
+
+      assert(targetRotationSetSpy.notCalled);
+    });
+
     it("should set the target's material opacity and transparency if the particle is using alpha", () => {
       const { particle, renderer } = setup();
 

--- a/test/utils/PUID.spec.js
+++ b/test/utils/PUID.spec.js
@@ -26,8 +26,8 @@ describe('utils -> PUID', () => {
 
     assert.strictEqual(NewPUID._id, 2);
     assert.strictEqual(nid2, 'PUID_1');
-    assert.strictEqual(NewPUID._uids[nid1], myObject);
-    assert.strictEqual(NewPUID._uids[nid2], myFunction);
+    assert.isTrue(NewPUID._uids.has(myObject));
+    assert.isTrue(NewPUID._uids.has(myFunction));
   });
 
   it('should not create a new id if the function or object has already been mapped', () => {


### PR DESCRIPTION
### Changed 

* `utils/PUID` now uses `Map` 
* `MeshRenderer` will no longer set rotation if the particle target is a `THREE.Sprite` instance