### PR TITLE
Lock sandbox to three@0.112.1

### DIFF
--- a/sandbox/experiments/gpu-rendered-point-zone/index.html
+++ b/sandbox/experiments/gpu-rendered-point-zone/index.html
@@ -12,7 +12,7 @@
       <canvas id="canvas"></canvas>
     </div>
 
-    <script src="https://threejs.org/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.112.1/build/three.js"></script>
     <script src="https://unpkg.com/three@0.112.1/examples/js/controls/OrbitControls.js"></script>
     <script src="https://unpkg.com/stats-js@1.0.1/build/stats.min.js"></script>
 

--- a/sandbox/experiments/gpu-renderer-depth-sorting/index.html
+++ b/sandbox/experiments/gpu-renderer-depth-sorting/index.html
@@ -16,7 +16,7 @@
       <canvas id="canvas"></canvas>
     </div>
 
-    <script src="https://threejs.org/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.112.1/build/three.js"></script>
     <script src="https://unpkg.com/three@0.112.1/examples/js/controls/OrbitControls.js"></script>
     <script src="https://unpkg.com/stats-js@1.0.1/build/stats.min.js"></script>
     <script src="/common/three-nebula.js"></script>

--- a/sandbox/experiments/gpu-renderer/index.html
+++ b/sandbox/experiments/gpu-renderer/index.html
@@ -12,7 +12,7 @@
       <canvas id="canvas"></canvas>
     </div>
 
-    <script src="https://threejs.org/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.112.1/build/three.js"></script>
     <script src="https://unpkg.com/three@0.112.1/examples/js/controls/OrbitControls.js"></script>
     <script src="https://unpkg.com/stats-js@1.0.1/build/stats.min.js"></script>
     <script src="/common/three-nebula.js"></script>

--- a/sandbox/experiments/gravity/index.html
+++ b/sandbox/experiments/gravity/index.html
@@ -12,7 +12,7 @@
       <canvas id="canvas"></canvas>
     </div>
 
-    <script src="https://threejs.org/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.112.1/build/three.js"></script>
     <script src="https://unpkg.com/three@0.112.1/examples/js/controls/OrbitControls.js"></script>
     <script src="https://unpkg.com/stats-js@1.0.1/build/stats.min.js"></script>
     <script src="/common/three-nebula.js"></script>

--- a/sandbox/experiments/multiple-emitters/index.html
+++ b/sandbox/experiments/multiple-emitters/index.html
@@ -12,7 +12,7 @@
       <canvas id="canvas"></canvas>
     </div>
 
-    <script src="https://threejs.org/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.112.1/build/three.js"></script>
     <script src="https://unpkg.com/three@0.112.1/examples/js/controls/OrbitControls.js"></script>
     <script src="https://unpkg.com/stats-js@1.0.1/build/stats.min.js"></script>
     <script src="/common/three-nebula.js"></script>


### PR DESCRIPTION
### Changed 

* Sandbox HTML has been locked to request three r112 as a newer version breaks the `GPURenderer` due to #117 