### PR TITLE
Bugfix/default auto emit to true

### DIFF
--- a/sandbox/experiments/gpu-renderer/index.js
+++ b/sandbox/experiments/gpu-renderer/index.js
@@ -5,9 +5,7 @@ window.init = async ({ scene, camera, renderer }) => {
   const spriteRenderer = new SpriteRenderer(scene, THREE);
   const pointsRenderer = new GPURenderer(scene, THREE);
   const systemRenderer = pointsRenderer;
-  const system = await System.fromJSONAsync(particleSystemState, THREE, {
-    shouldAutoEmit: true,
-  });
+  const system = await System.fromJSONAsync(particleSystemState, THREE);
 
   return system.addRenderer(systemRenderer);
 };

--- a/src/core/System.js
+++ b/src/core/System.js
@@ -102,12 +102,11 @@ export default class System {
    *
    * @param {object} json - The JSON to create the System instance from
    * @param {object} THREE - The Web GL Api to use eg., THREE
-   * @param {object} [options={}] - Optional config options
-   * @param {boolean} [options.shouldAutoEmit=true] - Determines if the system should automatically emit particles
+   * @param {?object} options - Optional config options
    * @return {Promise<System>}
    */
-  static fromJSONAsync(json, THREE, { shouldAutoEmit = false } = {}) {
-    return fromJSONAsync(json, THREE, System, Emitter, { shouldAutoEmit });
+  static fromJSONAsync(json, THREE, options) {
+    return fromJSONAsync(json, THREE, System, Emitter, options);
   }
 
   /**

--- a/src/core/fromJSON.js
+++ b/src/core/fromJSON.js
@@ -74,6 +74,8 @@ const makeBehaviours = items => {
 /**
  * Creates a System instance from a JSON object.
  *
+ * @deprecated Use fromJSONAsync instead.
+ *
  * @param {object} json - The JSON to create the System instance from
  * @param {object} THREE - The Web GL Api to use
  * @param {function} System - The system class

--- a/src/core/fromJSONAsync.js
+++ b/src/core/fromJSONAsync.js
@@ -11,6 +11,8 @@ import {
 import Rate from '../initializer/Rate';
 import TextureInitializer from '../initializer/Texture';
 
+const DEFAULT_OPTIONS = { shouldAutoEmit: true };
+
 /**
  * Makes a rate instance.
  *
@@ -202,11 +204,10 @@ const makeEmitters = (emitters, Emitter, THREE, shouldAutoEmit) =>
  * @param {object} THREE - The Web GL Api to use
  * @param {function} System - The system class
  * @param {function} Emitter - The emitter class
- * @param {object} options - Optional config options
- * @param {boolean} [options.shouldAutoEmit=true] - Determines if the system should automatically emit particles
+ * @param {object} [options={}] - Optional config options
  * @return {Promise<System>}
  */
-export default (json, THREE, System, Emitter, { shouldAutoEmit = true } = {}) =>
+export default (json, THREE, System, Emitter, options = {}) =>
   new Promise((resolve, reject) => {
     const {
       preParticles = POOL_MAX,
@@ -214,6 +215,7 @@ export default (json, THREE, System, Emitter, { shouldAutoEmit = true } = {}) =>
       emitters = [],
     } = json;
     const system = new System(preParticles, integrationType);
+    const { shouldAutoEmit } = { ...DEFAULT_OPTIONS, ...options };
 
     makeEmitters(emitters, Emitter, THREE, shouldAutoEmit)
       .then(madeEmitters => {

--- a/test/core/fromJSONAsync.spec.js
+++ b/test/core/fromJSONAsync.spec.js
@@ -133,6 +133,16 @@ describe('fromJSONAsync', () => {
     emitSpy.restore();
   });
 
+  it('should default to shouldAutoEmit is true', async () => {
+    const emitSpy = spy(Emitter.prototype, 'emit');
+
+    await Particles.fromJSONAsync(eightdiagrams, THREE);
+
+    assert(emitSpy.called);
+
+    emitSpy.restore();
+  });
+
   it("should not ever call an emitter's emit method if shouldAutoEmit option is false", async () => {
     const emitSpy = spy(Emitter.prototype, 'emit');
 


### PR DESCRIPTION
### Fixed 

* The `fromJSONAsync` function can now take an options arg, but it was defaulting `shouldAutoEmit` for the system to `false`. This was actually a mistake, it should have been defaulting it to `true`. 