### PR TITLE
fix a mismatch between PUID string and number

### DIFF
--- a/src/utils/PUID.js
+++ b/src/utils/PUID.js
@@ -2,7 +2,7 @@ export default {
   _id: 0,
   _uids: new Map(),
   getNewId: function() {
-    return `PUID_${this._id++}`;
+    return `PUID_${++this._id}`;
   },
   id: function(functionOrObject) {
     if (this._uids.has(functionOrObject)) {

--- a/test/utils/PUID.spec.js
+++ b/test/utils/PUID.spec.js
@@ -20,12 +20,12 @@ describe('utils -> PUID', () => {
     const nid1 = NewPUID.id(myObject);
 
     assert.strictEqual(NewPUID._id, 1);
-    assert.strictEqual(nid1, 'PUID_0');
+    assert.strictEqual(nid1, 'PUID_1');
 
     const nid2 = NewPUID.id(myFunction);
 
     assert.strictEqual(NewPUID._id, 2);
-    assert.strictEqual(nid2, 'PUID_1');
+    assert.strictEqual(nid2, 'PUID_2');
     assert.isTrue(NewPUID._uids.has(myObject));
     assert.isTrue(NewPUID._uids.has(myFunction));
   });


### PR DESCRIPTION
## Related Issues

- #66 PUID _id and returned id value do not match

## Purpose of this Pull Request

This PR is to fix a mismatch between PUID string and number.

## Details of the changes

Changed the postfix increment operator to prefix increment operator when generating strings. With this fix, the output string becomes a post-increment value.

For a more detailed description of postfix and prefix, please refer to the MDN documentation.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Increment#description