### PR TITLE
Bug Fix: allow emitted particles to live out their lives on stopEmit()

### DIFF
--- a/sandbox/common/Visualization.js
+++ b/sandbox/common/Visualization.js
@@ -106,7 +106,7 @@ window.Visualization = class {
       canvas: { clientWidth, clientHeight },
     } = this;
 
-    console.log(this);
+    //console.log(this);
 
     camera.aspect = clientWidth / clientHeight;
     camera.updateProjectionMatrix();

--- a/sandbox/experiments/gpu-rendered-point-zone/index.html
+++ b/sandbox/experiments/gpu-rendered-point-zone/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Multiple Emitters</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/experiments/gpu-rendered-point-zone/index.js
+++ b/sandbox/experiments/gpu-rendered-point-zone/index.js
@@ -101,9 +101,18 @@ window.init = async ({ scene, camera, renderer }) => {
   const color1 = new THREE.Color();
   const color2 = new THREE.Color();
   const emitter = createEmitter(color1, color2);
-  const systemRenderer = new GPURenderer(scene, THREE);
+  const systemRenderer = new GPURenderer(scene, renderer, THREE);
 
   animate({ color1, color2, emitter, camera, scene });
+
+  if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+  {
+    window.onresize = (e) => {
+      setTimeout(() => {
+        system.setSize(renderer.domElement.width,renderer.domElement.height);
+      },100)
+    }
+  }
 
   return system.addEmitter(emitter).addRenderer(systemRenderer);
 };

--- a/sandbox/experiments/gpu-renderer-depth-sorting/index.html
+++ b/sandbox/experiments/gpu-renderer-depth-sorting/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>GPU Renderer Depth Sorting</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/experiments/gpu-renderer-depth-sorting/index.js
+++ b/sandbox/experiments/gpu-renderer-depth-sorting/index.js
@@ -8,7 +8,7 @@ window.init = async ({ scene, camera, renderer }) => {
     new THREE.MeshPhongMaterial({ wireframe: false, color: 'red' })
   );
   const spriteRenderer = new SpriteRenderer(scene, THREE);
-  const gpuRenderer = new GPURenderer(scene, THREE, { camera });
+  const gpuRenderer = new GPURenderer(scene, renderer, THREE);
   const systemRenderer = gpuRenderer;
   const system = await System.fromJSONAsync(particleSystemState, THREE, {
     shouldAutoEmit: true,
@@ -16,6 +16,15 @@ window.init = async ({ scene, camera, renderer }) => {
 
   scene.add(new THREE.AmbientLight(0xffffff));
   scene.add(mesh);
+
+  if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+  {
+    window.onresize = (e) => {
+      setTimeout(() => {
+        system.setSize(renderer.domElement.width,renderer.domElement.height);
+      },100)
+    }
+  }
 
   return system.addRenderer(systemRenderer);
 };

--- a/sandbox/experiments/gpu-renderer-multiple-textures/index.html
+++ b/sandbox/experiments/gpu-renderer-multiple-textures/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>GPU Renderer</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/experiments/gpu-renderer-multiple-textures/index.html
+++ b/sandbox/experiments/gpu-renderer-multiple-textures/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>GPU Renderer</title>
+    <title>GPU Renderer Multiple Textures</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />

--- a/sandbox/experiments/gpu-renderer-multiple-textures/index.js
+++ b/sandbox/experiments/gpu-renderer-multiple-textures/index.js
@@ -2,12 +2,21 @@ const { System, GPURenderer, SpriteRenderer } = window.Nebula;
 
 window.init = async ({ scene, camera, renderer }) => {
   const { particleSystemState } = window.SYSTEM;
-  const systemRenderer = new GPURenderer(scene, THREE, {
+  const systemRenderer = new GPURenderer(scene, renderer, THREE, {
     shouldDebugTextureAtlas: true,
   });
   const system = await System.fromJSONAsync(particleSystemState, THREE, {
     shouldAutoEmit: true,
   });
+
+  if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+  {
+    window.onresize = (e) => {
+      setTimeout(() => {
+        system.setSize(renderer.domElement.width,renderer.domElement.height);
+      },100)
+    }
+  }
 
   return system.addRenderer(systemRenderer);
 };

--- a/sandbox/experiments/gpu-renderer/index.html
+++ b/sandbox/experiments/gpu-renderer/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>GPU Renderer</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/experiments/gpu-renderer/index.js
+++ b/sandbox/experiments/gpu-renderer/index.js
@@ -3,9 +3,18 @@ const { System, SpriteRenderer, GPURenderer } = window.Nebula;
 window.init = async ({ scene, camera, renderer }) => {
   const { particleSystemState } = window.SYSTEM;
   const spriteRenderer = new SpriteRenderer(scene, THREE);
-  const pointsRenderer = new GPURenderer(scene, THREE);
+  const pointsRenderer = new GPURenderer(scene, renderer, THREE);
   const systemRenderer = pointsRenderer;
   const system = await System.fromJSONAsync(particleSystemState, THREE);
+
+  if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+  {
+    window.onresize = (e) => {
+      setTimeout(() => {
+        system.setSize(renderer.domElement.width,renderer.domElement.height);
+      },100)
+    }
+  }
 
   return system.addRenderer(systemRenderer);
 };

--- a/sandbox/experiments/multiple-emitters/index.html
+++ b/sandbox/experiments/multiple-emitters/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Multiple Emitters</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/experiments/multiple-emitters/index.js
+++ b/sandbox/experiments/multiple-emitters/index.js
@@ -81,9 +81,18 @@ window.init = async ({ scene, camera, renderer }) => {
     renderer,
   });
   //const systemRenderer = new SpriteRenderer(scene, THREE);
-  const systemRenderer = new GPURenderer(scene, THREE);
+  const systemRenderer = new GPURenderer(scene, renderer, THREE);
 
   animateEmitters(emitterA, emitterB);
+
+  if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+  {
+    window.onresize = (e) => {
+      setTimeout(() => {
+        system.setSize(renderer.domElement.width,renderer.domElement.height);
+      },100)
+    }
+  }
 
   return system
     .addEmitter(emitterA)

--- a/sandbox/experiments/start-stop/data.js
+++ b/sandbox/experiments/start-stop/data.js
@@ -1,0 +1,146 @@
+window.SYSTEM = {
+  headerState: {
+    projectName: 'data',
+    version: { loading: false, error: null, data: null },
+    release: { loading: false, error: null, data: null },
+    shouldShowReleaseDownloadDialog: false,
+  },
+  particleSystemState: {
+    preParticles: 500,
+    integrationType: 'EULER',
+    emitters: [
+      {
+        id: '51ca9450-3d8b-11e9-a1e8-4785d9606b75',
+        totalEmitTimes: null,
+        life: null,
+        cache: { totalEmitTimes: 2, life: 0.5 },
+        rate: {
+          particlesMin: 1,
+          particlesMax: 4,
+          perSecondMin: 0.01,
+          perSecondMax: 0.02,
+        },
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        initializers: [
+          {
+            id: '51ca9451-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Mass',
+            properties: { min: 30, max: 10, isEnabled: true },
+          },
+          {
+            id: '51ca9452-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Life',
+            properties: { min: 2, max: 4, isEnabled: true },
+          },
+          {
+            id: '51ca9453-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'BodySprite',
+            properties: {
+              texture:
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAJkSURBVHjaxJeJbusgEEW94S1L//83X18M2MSuLd2pbqc4wZGqRLrKBsyZhQHny7Jk73xVL8xpVhWrcmiB5lX+6GJ5YgQ2owbAm8oIwH1VgKZUmGcRqKGGPgtEQQAzGR8hQ59fAmhJHSAagigJ4E7GPWRXOYC6owAd1JM6wDQPADyMWUqZRMqmAojHp1Vn6EQQEgUNMJLnUjMyJsM49wygBkAPw9dVFwXRkncCIIW3GRgoTQUZn6HxCMAFEFd8TwEQ78X4rHbILoAUmeT+RFG4UhQ6MiIAE4W/UsYFjuVjAIa2nIY4q1R0GFtQWG3E84lqw2GO2QOoCKBVu0BAPgDSU0eUDjjQenNkV/AW/pWChhpMTelo1a64AOKM30vk18GzTHXCNtI/Knz3DFBgsUqBGIjTInXRY1yA9xkVoqW5tVq3pDR9A0hfF5BSARmVnh7RMDCaIdcNgbPBkgzn1Bu+SfIEFSpSBmkxyrMicb0fAEuCZrWnN89veA/4XcakrPcjBWzkTuLjlbfTQPOlBhz+HwkqqPXmPQDdrQItxE1moGof1S74j/8txk8EHhTQrAE8qlwfqS5yukm1x/rAJ9Jiaa6nyATqD78aUVBhFo8b1V4DdTXdCW+IxA1zB4JhiOhZMEWO1HqnvdoHZ4FAMIhV9REF8FiUm0jsYPEJx/Fm/N8OhH90HI9YRHesWbXXZwAShU8qThe7H8YAuJmw5yOd989uRINKRTJAhoF8jbqrHKfeCYdIISZfSq26bk/K+yO3YvfKrVgiwQBHnwt8ynPB25+M8hceTt/ybPhnryJ78+tLgAEAuCFyiQgQB30AAAAASUVORK5CYII=',
+              isEnabled: true,
+            },
+          },
+          {
+            id: '51ca9454-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Radius',
+            properties: { width: 12, height: 4, isEnabled: true },
+          },
+          {
+            id: '51ca9455-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'RadialVelocity',
+            properties: {
+              radius: 10,
+              x: 0,
+              y: 5,
+              z: 0,
+              theta: 900,
+              isEnabled: true,
+            },
+          },
+        ],
+        behaviours: [
+          {
+            id: '51ca9456-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Alpha',
+            properties: {
+              alphaA: 1,
+              alphaB: 0,
+              life: null,
+              easing: 'easeLinear',
+            },
+          },
+          {
+            id: '51ca9457-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Color',
+            properties: {
+              colorA: '#002a4f',
+              colorB: '#0029FF',
+              life: null,
+              easing: 'easeOutCubic',
+            },
+          },
+          {
+            id: '51ca9458-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Scale',
+            properties: {
+              scaleA: 1,
+              scaleB: 0.5,
+              life: null,
+              easing: 'easeLinear',
+            },
+          },
+          {
+            id: '51ca9459-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Force',
+            properties: {
+              fx: 0,
+              fy: 5,
+              fz: 0,
+              life: null,
+              easing: 'easeLinear',
+            },
+          },
+          {
+            id: '51ca945a-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Rotate',
+            properties: {
+              x: 1,
+              y: 0,
+              z: 0,
+              life: null,
+              easing: 'easeLinear',
+            },
+          },
+          {
+            id: '51ca945b-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'RandomDrift',
+            properties: {
+              driftX: 1,
+              driftY: 23,
+              driftZ: 4,
+              delay: 1,
+              life: null,
+              easing: 'easeLinear',
+            },
+          },
+          {
+            id: '51ca945c-3d8b-11e9-a1e8-4785d9606b75',
+            type: 'Spring',
+            properties: {
+              x: 1,
+              y: 5,
+              z: 0,
+              spring: 0.01,
+              friction: 1,
+              life: null,
+              easing: 'easeLinear',
+            },
+          },
+        ],
+        emitterBehaviours: [],
+      },
+    ],
+  },
+};

--- a/sandbox/experiments/start-stop/index.html
+++ b/sandbox/experiments/start-stop/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Emitter Start Stop</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/experiments/start-stop/index.html
+++ b/sandbox/experiments/start-stop/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Emitter Start Stop</title>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <div id="ui">
+        <button id="start">start emitter</button>
+        <button id="stop">stop emitter</button>
+      </div>
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script src="https://unpkg.com/three@0.122.0/build/three.js"></script>
+    <script src="https://unpkg.com/three@0.122.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="https://unpkg.com/stats-js@1.0.1/build/stats.min.js"></script>
+    <script src="/common/three-nebula.js"></script>
+    <script src="/common/Visualization.js"></script>
+    <script src="/common/safeLog.js"></script>
+    <script src="/common/run.js"></script>
+    <script src="/experiments/start-stop/data.js"></script>
+    <script src="/experiments/start-stop/index.js"></script>
+    <script>
+      run(init).then(() => console.log(`APP LOADED`));
+    </script>
+  </body>
+</html>

--- a/sandbox/experiments/start-stop/index.js
+++ b/sandbox/experiments/start-stop/index.js
@@ -9,7 +9,7 @@ const { start, stop } = {
 window.init = async ({ scene, camera, renderer }) => {
   const { particleSystemState } = window.SYSTEM;
   const spriteRenderer = new SpriteRenderer(scene, THREE);
-  const pointsRenderer = new GPURenderer(scene, THREE);
+  const pointsRenderer = new GPURenderer(scene, renderer, THREE);
   const systemRenderer = pointsRenderer;
   const system = await System.fromJSONAsync(particleSystemState, THREE, { shouldAutoEmit: false });
 
@@ -20,6 +20,15 @@ window.init = async ({ scene, camera, renderer }) => {
   stop.addEventListener('click', () => {
     system.emitters[0].stopEmit();
   });
+
+  if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+  {
+    window.onresize = (e) => {
+      setTimeout(() => {
+        system.setSize(renderer.domElement.width,renderer.domElement.height);
+      },100)
+    }
+  }
 
   return system.addRenderer(systemRenderer);
 };

--- a/sandbox/experiments/start-stop/index.js
+++ b/sandbox/experiments/start-stop/index.js
@@ -1,0 +1,25 @@
+const { System, SpriteRenderer, GPURenderer } = window.Nebula;
+
+const button = id => document.getElementById(id);
+const { start, stop } = {
+  start: button('start'),
+  stop: button('stop'),
+};
+
+window.init = async ({ scene, camera, renderer }) => {
+  const { particleSystemState } = window.SYSTEM;
+  const spriteRenderer = new SpriteRenderer(scene, THREE);
+  const pointsRenderer = new GPURenderer(scene, THREE);
+  const systemRenderer = pointsRenderer;
+  const system = await System.fromJSONAsync(particleSystemState, THREE, { shouldAutoEmit: false });
+
+  start.addEventListener('click', () => {
+    system.emitters[0].emit();
+  });
+
+  stop.addEventListener('click', () => {
+    system.emitters[0].stopEmit();
+  });
+
+  return system.addRenderer(systemRenderer);
+};

--- a/sandbox/experiments/texture-atlas-disposal/index.html
+++ b/sandbox/experiments/texture-atlas-disposal/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>GPU Renderer</title>
+    <title>Texture Atlas Disposal</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Three Nebula Simple Sandbox</title>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />
     <link rel="stylesheet" type="text/css" href="/style/app.css" />
   </head>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -16,6 +16,11 @@
           </a>
         </li>
         <li>
+          <a href="experiments/start-stop/index.html">
+            Start-Stop
+          </a>
+        </li>
+        <li>
           <a href="experiments/gpu-renderer/index.html">
             GPU Renderer
           </a>

--- a/src/core/System.js
+++ b/src/core/System.js
@@ -13,6 +13,12 @@ import Pool from './Pool';
 import fromJSON from './fromJSON';
 import fromJSONAsync from './fromJSONAsync';
 import { CORE_TYPE_SYSTEM as type } from './types';
+import { 
+  RENDERER_TYPE_GPU,
+  RENDERER_TYPE_GPU_MOBILE,
+  RENDERER_TYPE_GPU_DESKTOP,
+} from '../renderer/types';
+
 
 /**
  * The core of the three-system particle engine.
@@ -271,6 +277,23 @@ export default class System {
     }
 
     return Promise.resolve();
+  }
+
+  /**
+   * Updates the size/dimensions of the three.js renderer/canvas. (only applicable to the GPU renderers)
+   * The particles are then scaled relatively to the renderer/canvas height, keeping them a consistent proportional size regardless of the canvas dimensions
+   */
+  setSize(width,height) {
+
+    this.renderers.forEach( renderer => {
+     
+      if(renderer.type === RENDERER_TYPE_GPU || renderer.type === RENDERER_TYPE_GPU_MOBILE || renderer.type === RENDERER_TYPE_GPU_DESKTOP)
+      {
+        renderer.updateThreeRendererSize(width,height);
+      }
+
+    });
+
   }
 
   /**

--- a/src/core/System.js
+++ b/src/core/System.js
@@ -263,7 +263,7 @@ export default class System {
           const emitter = this.emitters[i];
 
           emitter.update(d);
-          emitter.isEmitting && this.dispatch(SYSTEM_UPDATE);
+          emitter.particles.length && this.dispatch(SYSTEM_UPDATE);
         }
       }
 

--- a/src/emitter/Emitter.js
+++ b/src/emitter/Emitter.js
@@ -558,7 +558,7 @@ export default class Emitter extends Particle {
    * @return void
    */
   update(time) {
-    if (!this.isEmitting) {
+    if (!this.isEmitting && this.particles.length === 0) {
       return;
     }
 
@@ -568,7 +568,11 @@ export default class Emitter extends Particle {
       this.destroy();
     }
 
-    this.generate(time);
+    if (this.isEmitting)
+    {
+      this.generate(time);
+    }
+
     this.integrate(time);
 
     let i = this.particles.length;

--- a/src/renderer/GPURenderer/Desktop/index.js
+++ b/src/renderer/GPURenderer/Desktop/index.js
@@ -15,7 +15,7 @@ let THREE;
  * @author rohan-deshpande <rohan@creativelifeform.com>
  */
 export default class DesktopGPURenderer extends BaseRenderer {
-  constructor(container, three, options = DEFAULT_RENDERER_OPTIONS) {
+  constructor(container, threeRenderer, three, options = DEFAULT_RENDERER_OPTIONS) {
     super(RENDERER_TYPE_GPU_DESKTOP);
 
     THREE = this.three = three;
@@ -36,6 +36,7 @@ export default class DesktopGPURenderer extends BaseRenderer {
         baseColor: { value: new THREE.Color(baseColor) },
         uTexture: { value: null },
         atlasIndex: { value: null },
+        threeRendererHeight: { value: threeRenderer.domElement.height },
       },
       vertexShader: vertexShader(),
       fragmentShader: fragmentShader(),
@@ -111,6 +112,18 @@ export default class DesktopGPURenderer extends BaseRenderer {
     this.mapParticleTargetPropsToPoint(particle);
 
     particle.target = null;
+  }
+
+
+  /**
+   * Updates the threeRendererHeight uniform to keep gl_PointSize sizes relative to the three.js renderer height.
+   * (without this the particle sizes vary across different device/canvas sizes)
+   * 
+   * @param {width}
+   * @param {height}
+   */
+  updateThreeRendererSize(width,height) {
+    this.material.uniforms.threeRendererHeight.value = height;
   }
 
   /**

--- a/src/renderer/GPURenderer/Desktop/shaders/vertexShader.js
+++ b/src/renderer/GPURenderer/Desktop/shaders/vertexShader.js
@@ -6,6 +6,7 @@ export const vertexShader = () => {
     uniform sampler2D uTexture;
     //atlasIndex is a 256x1 float texture of tile rectangles as r=minx g=miny b=maxx a=maxy
     uniform sampler2D atlasIndex;
+    uniform float threeRendererHeight;
 
     attribute float size;
     attribute vec3 color;
@@ -26,7 +27,7 @@ export const vertexShader = () => {
       //get the tile rectangle from the atlasIndex texture..
       tileRect = texture2D(atlasIndex, vec2((tileID + 0.5) / ${DATA_TEXTURE_SIZE}.0, 0.5));
 
-      gl_PointSize = ((size * ${SIZE_ATTENUATION_FACTOR}) / -mvPosition.z);
+      gl_PointSize = ((size * threeRendererHeight * ${SIZE_ATTENUATION_FACTOR}) / -mvPosition.z);
       gl_Position = projectionMatrix * mvPosition;
     }
 `;

--- a/src/renderer/GPURenderer/Mobile/index.js
+++ b/src/renderer/GPURenderer/Mobile/index.js
@@ -15,7 +15,7 @@ let THREE;
  * @author rohan-deshpande <rohan@creativelifeform.com>
  */
 export default class MobileGPURenderer extends BaseRenderer {
-  constructor(container, three, options = DEFAULT_RENDERER_OPTIONS) {
+  constructor(container, threeRenderer, three, options = DEFAULT_RENDERER_OPTIONS) {
     super(RENDERER_TYPE_GPU_MOBILE);
 
     THREE = this.three = three;
@@ -37,6 +37,7 @@ export default class MobileGPURenderer extends BaseRenderer {
         uTexture: { value: null },
         FFatlasIndex: { value: null },
         atlasDim: { value: new THREE.Vector2() },
+        threeRendererHeight: { value: threeRenderer.domElement.height },
       },
       vertexShader: vertexShader(),
       fragmentShader: fragmentShader(),
@@ -119,6 +120,17 @@ export default class MobileGPURenderer extends BaseRenderer {
     this.mapParticleTargetPropsToPoint(particle);
 
     particle.target = null;
+  }
+
+  /**
+   * Updates the threeRendererHeight uniform to keep gl_PointSize sizes relative to the three.js renderer height.
+   * (without this the particle sizes vary across different device/canvas sizes)
+   * 
+   * @param {width}
+   * @param {height}
+   */
+  updateThreeRendererSize(width,height) {
+    this.material.uniforms.threeRendererHeight.value = height;
   }
 
   /**

--- a/src/renderer/GPURenderer/Mobile/shaders/vertexShader.js
+++ b/src/renderer/GPURenderer/Mobile/shaders/vertexShader.js
@@ -4,6 +4,7 @@ export const vertexShader = () => {
   return `
     uniform sampler2D uTexture;
     uniform vec2 atlasDim;
+    uniform float threeRendererHeight;
 
     attribute float size;
     attribute vec3 color;
@@ -23,7 +24,7 @@ export const vertexShader = () => {
       vec2 tmax = fract(texID);
       tileRect = vec4(tmin,tmax);
 
-      gl_PointSize = ((size * ${SIZE_ATTENUATION_FACTOR}) / -mvPosition.z);
+      gl_PointSize = ((size * threeRendererHeight * ${SIZE_ATTENUATION_FACTOR}) / -mvPosition.z);
       gl_Position = projectionMatrix * mvPosition;
     }
 `;

--- a/src/renderer/GPURenderer/common/shaders/constants.js
+++ b/src/renderer/GPURenderer/common/shaders/constants.js
@@ -1,1 +1,1 @@
-export const SIZE_ATTENUATION_FACTOR = '600.0';
+export const SIZE_ATTENUATION_FACTOR = '0.71';

--- a/src/renderer/GPURenderer/index.js
+++ b/src/renderer/GPURenderer/index.js
@@ -16,11 +16,11 @@ import { RENDERER_TYPE_GPU } from '../types';
  * @author rohan-deshpande <rohan@creativelifeform.com>
  */
 export default class GPURenderer extends BaseRenderer {
-  constructor(container, THREE, options = DEFAULT_RENDERER_OPTIONS) {
+  constructor(container, threeRenderer, THREE, options = DEFAULT_RENDERER_OPTIONS) {
     super(RENDERER_TYPE_GPU);
 
     const { shouldForceDesktopRenderer, shouldForceMobileRenderer } = options;
-    const args = [container, THREE, options];
+    const args = [container, threeRenderer, THREE, options];
 
     if (shouldForceDesktopRenderer) {
       return new DesktopGPURenderer(...args);

--- a/website/components/Examples/GpuRenderer/init.js
+++ b/website/components/Examples/GpuRenderer/init.js
@@ -92,7 +92,7 @@ const createEmitter = (color1, color2) => {
     .emit();
 };
 
-export default async (three, { scene, camera }) => {
+export default async (three, { scene, camera, renderer }) => {
   THREE = three;
 
   const system = new ParticleSystem();
@@ -102,5 +102,5 @@ export default async (three, { scene, camera }) => {
 
   animate({ color1, color2, emitter, camera, scene });
 
-  return system.addEmitter(emitter).addRenderer(new GPURenderer(scene, THREE));
+  return system.addEmitter(emitter).addRenderer(new GPURenderer(scene, renderer, THREE));
 };

--- a/website/components/Examples/GpuRenderer/init.js
+++ b/website/components/Examples/GpuRenderer/init.js
@@ -102,5 +102,7 @@ export default async (three, { scene, camera, renderer }) => {
 
   animate({ color1, color2, emitter, camera, scene });
 
-  return system.addEmitter(emitter).addRenderer(new GPURenderer(scene, renderer, THREE));
+  return system
+    .addEmitter(emitter)
+    .addRenderer(new GPURenderer(scene, renderer, THREE));
 };

--- a/website/components/primitives/Nebula/index.js
+++ b/website/components/primitives/Nebula/index.js
@@ -82,16 +82,18 @@ export class Nebula extends Component {
   setCanvasSize(callback) {
     const { offsetWidth: width = 0, offsetHeight: height = 0 } =
       this.container || {};
-    
+
     const system = this.renderer?.particleSystem;
 
-    if(system)
-    {
+    if (system) {
       const systemRenderer = system.renderers[0];
 
-      if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
-      {
-        system.setSize(width,height);
+      if (
+        systemRenderer.type === 'GPURenderer' ||
+        systemRenderer.type === 'MobileGPURenderer' ||
+        systemRenderer.type === 'DesktopGPURenderer'
+      ) {
+        system.setSize(width, height);
       }
     }
 

--- a/website/components/primitives/Nebula/index.js
+++ b/website/components/primitives/Nebula/index.js
@@ -82,6 +82,18 @@ export class Nebula extends Component {
   setCanvasSize(callback) {
     const { offsetWidth: width = 0, offsetHeight: height = 0 } =
       this.container || {};
+    
+    const system = this.renderer?.particleSystem;
+
+    if(system)
+    {
+      const systemRenderer = system.renderers[0];
+
+      if(systemRenderer.type === 'GPURenderer' || systemRenderer.type === 'MobileGPURenderer' || systemRenderer.type === 'DesktopGPURenderer')
+      {
+        system.setSize(width,height);
+      }
+    }
 
     this.setState({ width, height }, callback);
   }

--- a/website/components/primitives/Nebula/renderer/Json.js
+++ b/website/components/primitives/Nebula/renderer/Json.js
@@ -46,7 +46,9 @@ export class JsonRenderer extends BaseRenderer {
         .then(particleSystem => {
           this.particleSystem = particleSystem;
 
-          particleSystem.addRenderer(new GPURenderer(this.scene, this.webGlRenderer, THREE));
+          particleSystem.addRenderer(
+            new GPURenderer(this.scene, this.webGlRenderer, THREE)
+          );
 
           if (shouldExposeLifeCycleApi) {
             particleSystem.emit({

--- a/website/components/primitives/Nebula/renderer/Json.js
+++ b/website/components/primitives/Nebula/renderer/Json.js
@@ -46,7 +46,7 @@ export class JsonRenderer extends BaseRenderer {
         .then(particleSystem => {
           this.particleSystem = particleSystem;
 
-          particleSystem.addRenderer(new GPURenderer(this.scene, THREE));
+          particleSystem.addRenderer(new GPURenderer(this.scene, this.webGlRenderer, THREE));
 
           if (shouldExposeLifeCycleApi) {
             particleSystem.emit({


### PR DESCRIPTION
This fixes a bug where emitted particles would stop animating when calling stopEmit() on an emitter.  Now they will live out the rest of their life cycle completely.

This should close this issue: https://github.com/creativelifeform/three-nebula/issues/169

I also built a sandbox example to illustrate/test this, and it seems to work fine with both the gpu-renderer and the sprite-renderer.
