### PR TITLE
Add runtime modernisation specs (01–05)

### DIFF
--- a/specs/01-emitter-hierarchy.md
+++ b/specs/01-emitter-hierarchy.md
@@ -1,0 +1,197 @@
+# Spec 01 — Emitter Hierarchy
+
+Nested child emitters, ribbon/trail renderers, and the pooling required to make
+both survivable.
+
+**Depends on:** 04 (schema versioning) — this spec breaks the schema.
+**Entangled with:** 02 (determinism) — child seeds derive from parent particle IDs.
+
+---
+
+## Problem
+
+Today three-nebula emitters are siblings: a flat list, all anchored to the system
+transform, running in parallel with no knowledge of each other. This is fine for
+effects that happen *at one place* — fire, rain, explosions.
+
+It cannot express effects that ride individual particles. *Every spark leaves its
+own smoke trail* is unrepresentable: a sibling smoke emitter has exactly one
+position and the sparks have twenty.
+
+Parent-child emitters change the cardinality. The child is instanced **once per
+parent particle**. 20 sparks → 20 live child emitter instances, each riding one
+spark, each dying with it.
+
+Ribbons and trails are grouped in here because they are the payoff: a child
+emitter with `onCreate` inheritance leaving a ribbon along a parent's path is the
+sword-arc effect, and it only exists once hierarchy exists.
+
+---
+
+## Stage 0 — Audit
+
+Before writing code, establish:
+
+1. Does particle pooling exist? Where? Is it per-emitter or global?
+2. Do particles carry a stable, monotonic ID? If not, what identifies them?
+3. What is the exact renderer interface? Enumerate its lifecycle hooks.
+4. How does `System.update()` order emitter updates today?
+5. Is there any existing concept of emitter-to-emitter reference?
+6. How are emitters serialised in the current JSON schema?
+
+**Write the answers into this spec before proceeding.** Stages 1–4 assume answers
+that may be wrong.
+
+---
+
+## Stage 1 — Pooling foundation
+
+Pooling is currently a nice-to-have. After Stage 2 it is load-bearing: nested
+emitters multiply cardinality (100 parents × 50 children = 5,000 particles and
+100 emitter instances), and child instances must be recycled on parent death or
+the system leaks.
+
+**Deliverables:**
+
+- A pool for particles (may already exist — see audit)
+- A pool for **emitter instances** (new)
+- Explicit `acquire()` / `release()` with no allocation in the hot path
+- A global cap on live emitter instances, configurable, with a documented
+  overflow policy (drop-newest is usually right for FX)
+- Instrumentation: live counts for particles, emitter instances, pool hits/misses
+
+**Acceptance:** a 60-second run of a nested system shows zero growth in heap
+allocation attributable to particle or emitter instance churn.
+
+---
+
+## Stage 2 — The emitter tree
+
+**Schema change.** `system.emitters[]` becomes a tree. Each emitter node gains
+`children: Emitter[]`.
+
+```jsonc
+{
+  "version": 2,
+  "emitters": [
+    {
+      "id": "sparks",
+      "rate": { /* ... */ },
+      "initializers": [ /* ... */ ],
+      "behaviours": [ /* ... */ ],
+      "renderer": { "type": "sprite", /* ... */ },
+      "children": [
+        {
+          "id": "spark-smoke",
+          "inherit": { "position": "always", "rotation": "none", "scale": "none" },
+          "rate": { /* ... */ },
+          "renderer": { "type": "sprite", /* ... */ },
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Semantics:**
+
+- A child emitter is **instantiated once per parent particle**, at that particle's
+  spawn.
+- The child instance's origin is the parent particle, not the system.
+- The child instance is destroyed when its parent particle dies. Its already-emitted
+  particles may either die with it or live out their lifetimes — this is a per-node
+  flag, `orphanPolicy: "kill" | "detach"`. Default `detach` (a spark's smoke should
+  outlive the spark).
+- Update order is **topological**: a parent's particles must resolve before its
+  children read their transforms. Depth-first is fine.
+
+**Guards:**
+
+- `maxDepth` — hard recursion limit. Effekseer has a known footgun where
+  self-triggering recursive nodes retain every prior instance until the last child
+  dies. Cap depth (suggest 4) and cap total instances (Stage 1).
+- Reject cycles at parse time.
+
+**Acceptance:** a two-level system (sparks → smoke trails) renders correctly;
+killing the system releases all child instances; instance count is bounded.
+
+---
+
+## Stage 3 — Inheritance modes
+
+Per channel — `position`, `rotation`, `scale` — with three modes:
+
+| Mode | Behaviour | Use |
+|------|-----------|-----|
+| `always` | Child continuously tracks parent particle | Trails, attached FX |
+| `onCreate` | Child snapshots parent transform at spawn, then free | Ribbons, tracks, debris |
+| `none` | Child ignores parent transform (system-space) | Rare; events |
+
+`onCreate` vs `always` is the same hierarchy producing opposite looks from one
+dropdown. It is the single highest-value nuance in this spec — do not skip it.
+
+**Acceptance:** switching `position` from `always` to `onCreate` on the same
+system visibly converts an attached trail into a left-behind band.
+
+---
+
+## Stage 4 — Ribbon and Trail renderers
+
+**These are two different things and should be two renderers.** Conflating them
+is a common mistake.
+
+### `RibbonRenderer`
+
+Connects **sibling particles of one emitter** into a continuous strip, in spawn
+order. The particles are the spine.
+
+- Requires stable spawn ordering (see 02 — particle IDs)
+- Width driven by a curve over particle age
+- Texture UV: `stretch` (U maps 0→1 across the whole ribbon) or `tile`
+  (U repeats per segment). Both are needed; stretch is the common default.
+- Geometry: triangle strip, camera-facing by default; optional axis-aligned
+- Handle the degenerate cases: fewer than 2 live particles, particles at
+  identical positions (zero-length segments produce NaN normals)
+
+### `TrailRenderer`
+
+Each particle keeps a **ring buffer of its own past positions** and renders a tail.
+No sibling relationship.
+
+- `trailLength` (samples) and `sampleInterval` (seconds) per particle
+- Memory cost is `particles × trailLength × 3 floats` — must be pooled (Stage 1)
+- Same width-over-age and UV modes as ribbon
+
+**Which to build first:** Ribbon. It composes with Stage 3's `onCreate` mode to
+give sword arcs, and it's cheaper. Trail is the fallback for when you want a tail
+without a child emitter.
+
+**Acceptance:** a child emitter with `inherit.position: "onCreate"` and a
+`RibbonRenderer` produces a coherent band along the parent's path.
+
+---
+
+## Stage 5 — Events (deferred, scope permitting)
+
+Distinct from attachment. Attachment = child lives alongside parent for its
+lifetime (Stages 2–3). Events = a discrete trigger that spawns a burst which then
+**outlives** the parent.
+
+- `onDeath` → spawn burst at parent's final position
+- `onCollision` → spawn burst at contact point
+
+Fireworks want events. Trails want attachment. Ship attachment first; events are
+a clean additive follow-on and should not block Stages 1–4.
+
+---
+
+## Notes for implementation
+
+- Particles stay dumb. Nothing about hierarchy enters the particle struct except
+  an ID (which 02 needs anyway). Child emitter instances hold the parent reference,
+  not the other way round.
+- The child instance is an *emitter*, not a *particle*. Do not try to model it as
+  a special particle type.
+- Every new random draw in this spec must go through the seeded PRNG from 02.
+  Child instance seeds derive from `hash(systemSeed, emitterId, parentParticleId)`.

--- a/specs/01-emitter-hierarchy.md
+++ b/specs/01-emitter-hierarchy.md
@@ -108,9 +108,12 @@ allocation attributable to particle or emitter instance churn.
 
 **Guards:**
 
-- `maxDepth` — hard recursion limit. Effekseer has a known footgun where
-  self-triggering recursive nodes retain every prior instance until the last child
-  dies. Cap depth (suggest 4) and cap total instances (Stage 1).
+- `maxDepth` — hard recursion limit. Self-triggering recursive nodes are a known
+  hazard in any hierarchical particle system: every ancestor instance is retained
+  until its last descendant dies, so an unbounded chain leaks until it exhausts
+  memory. Cap depth (suggest 4) and cap total instances (Stage 1).
+  *Prior art:* Effekseer permits recursion in its node tree — its documentation on
+  instance retention is worth reading before designing this guard.
 - Reject cycles at parse time.
 
 **Acceptance:** a two-level system (sparks → smoke trails) renders correctly;

--- a/specs/02-determinism-scrubbing.md
+++ b/specs/02-determinism-scrubbing.md
@@ -1,0 +1,154 @@
+# Spec 02 — Determinism & Scrubbing
+
+Make the simulation reproducible: same seed + same step count = byte-identical
+particle state, every time, on every machine running the same JS engine.
+
+**Entangled with:** 01 (hierarchy) — child seeds derive from parent particle IDs
+
+---
+
+## Why this is not optional
+
+Determinism looks like a nicety. It is actually the load-bearing property under
+four separate product features:
+
+1. **Gallery thumbnails** must match what the user saw when they published.
+2. **Baked export** — two bakes of the same system must be identical
+3. **Nebula Editor scrubbing** — seek, step, edit-while-paused. The single most-used
+   affordance in commercial FX editors.
+4. **AI generation loop** — generate → bake N frames → critique → revise only
+   works if the render is a function of the JSON.
+
+Retrofitting determinism means touching every initializer and behaviour. Doing it
+while already in there for 01 costs a fraction.
+
+---
+
+## Stage 0 — Audit
+
+1. Grep for `Math.random`. Every hit is a defect. Count them.
+2. Grep for `Date.now`, `performance.now`, `new Date` inside the sim path.
+3. Does the sim use a fixed timestep or raw `delta` from rAF?
+4. Do particles have IDs? Are they stable across frames?
+5. Is there any iteration over `Set` / `Map` / `Object.keys` whose order affects
+   simulation output?
+6. Is there existing seed handling anywhere?
+
+---
+
+## Stage 1 — Seeded PRNG
+
+Replace all `Math.random()` with an injected, seedable generator.
+
+- Suggested: `mulberry32` or `xoshiro128**`. Small state, fast, good enough
+  distribution for FX. Do not use anything cryptographic.
+- The PRNG instance must be reachable from every initializer, behaviour, and
+  renderer that draws randomness. Pass it down; do not use a module singleton
+  (two systems on one page must not share a stream).
+
+**Acceptance:** `grep -r "Math.random" src/` returns zero hits in the sim path.
+
+---
+
+## Stage 2 — Seed derivation hierarchy
+
+Randomness must be *addressable*, not merely seeded. A single sequential stream
+breaks the moment emitters update in a different order.
+
+```
+systemSeed                         (user-set or random at creation)
+  └─ emitterSeed   = hash(systemSeed, emitterId)
+       └─ particleSeed = hash(emitterSeed, particleId)
+            └─ childEmitterSeed = hash(systemSeed, childEmitterId, particleId)
+```
+
+- `particleId` — monotonic counter per emitter, never reused, survives pooling
+  (i.e. a recycled particle object gets a *new* ID)
+- Each particle carries its own PRNG state, seeded from `particleSeed`
+- This is what makes 01's child emitters reproducible: the child's stream is a
+  pure function of which parent particle it rides
+
+**Acceptance:** reordering emitters in the JSON does not change any individual
+emitter's output.
+
+---
+
+## Stage 3 — Fixed timestep
+
+The sim must advance in fixed increments, decoupled from rAF.
+
+- Accumulator pattern: accumulate real delta, consume in fixed steps
+  (suggest 1/60s, configurable)
+- Clamp max steps per frame to avoid spiral-of-death on a slow frame
+- Optionally interpolate render state between steps (defer — not needed for v1)
+
+Without this, the same system produces different results on a 60Hz and a 144Hz
+display, and baking at a different fps produces a different effect.
+
+**Acceptance:** stepping the sim 600× at 1/60 produces identical state regardless
+of wall-clock time taken.
+
+---
+
+## Stage 4 — Seek / scrub
+
+**You cannot run a stochastic sim backwards.** Do not try.
+
+Seek is implemented as **reset + fast-forward**:
+
+```
+seek(t):
+  reset to step 0 with the same seed
+  run ceil(t / dt) fixed steps with rendering disabled
+```
+
+- Forward seek from the current position is an optimisation, not a requirement —
+  correctness first
+- **Checkpointing** (snapshot full particle state every N steps, restore + replay
+  the remainder) is the obvious speed-up if seek becomes slow. Defer until measured.
+- Scrubbing must not fire audio (see 03) or any other side effect
+- Expose `step()`, `seek(t)`, `reset()`, `setTimeScale()` on the system
+
+**Acceptance:** `seek(2.0)` twice from different starting states produces
+identical particle buffers.
+
+---
+
+## Stage 5 — The determinism test
+
+This is the deliverable that keeps the property from rotting.
+
+- Hash the full particle buffer (positions, velocities, colors, ages) at
+  step N into a stable digest
+- Golden-file test: a corpus of systems, each with an expected digest at several
+  step counts
+- Run in CI. Any change that breaks a digest is either a bug or an intentional
+  change requiring a new golden file
+- Include at least one nested system once 01 lands
+
+**Acceptance:** CI fails if determinism regresses.
+
+---
+
+## Known non-determinism sources to eliminate
+
+| Source | Fix |
+|--------|-----|
+| `Math.random()` | Seeded PRNG (Stage 1) |
+| `Date.now()` / `performance.now()` in sim | Fixed timestep (Stage 3) |
+| Variable rAF delta | Fixed timestep (Stage 3) |
+| `Set`/`Map` iteration order | Sort, or use arrays |
+| Pool reuse order affecting IDs | IDs from a counter, not pool index |
+| Async texture load racing spawn | Resolve all assets before first step |
+
+**Not a concern:** IEEE-754 float behaviour is deterministic within a given JS
+engine on a given platform. Cross-platform float divergence matters for lockstep
+netcode, not for this. Do not over-engineer.
+
+---
+
+## Explicitly out of scope
+
+- Cross-engine determinism (three-nebula ↔ some future Unity runtime)
+- Rewind / reverse simulation
+- Deterministic GPU simulation (revisit if/when a compute path exists)

--- a/specs/02-determinism-scrubbing.md
+++ b/specs/02-determinism-scrubbing.md
@@ -3,6 +3,7 @@
 Make the simulation reproducible: same seed + same step count = byte-identical
 particle state, every time, on every machine running the same JS engine.
 
+**Blocks:** 03 (sound jitter), and any offline/headless rendering built on the library
 **Entangled with:** 01 (hierarchy) — child seeds derive from parent particle IDs
 
 ---
@@ -12,12 +13,12 @@ particle state, every time, on every machine running the same JS engine.
 Determinism looks like a nicety. It is actually the load-bearing property under
 four separate product features:
 
-1. **Gallery thumbnails** must match what the user saw when they published.
-2. **Baked export** — two bakes of the same system must be identical
-3. **Nebula Editor scrubbing** — seek, step, edit-while-paused. The single most-used
-   affordance in commercial FX editors.
-4. **AI generation loop** — generate → bake N frames → critique → revise only
-   works if the render is a function of the JSON.
+1. **Reproducible rendering** — a headless render must match what was seen live.
+2. **Offline rendering** — two renders of one system must be byte-identical.
+3. **Seek and scrub** — step, rewind, edit-while-paused in any editing tool built
+   on the library. The single most-used affordance in mature FX tooling.
+4. **Programmatic iteration** — render → inspect → revise loops only work if the
+   output is a pure function of the input.
 
 Retrofitting determinism means touching every initializer and behaviour. Doing it
 while already in there for 01 costs a fraction.
@@ -83,7 +84,7 @@ The sim must advance in fixed increments, decoupled from rAF.
 - Optionally interpolate render state between steps (defer — not needed for v1)
 
 Without this, the same system produces different results on a 60Hz and a 144Hz
-display, and baking at a different fps produces a different effect.
+display, and rendering offline at a different fps produces a different effect.
 
 **Acceptance:** stepping the sim 600× at 1/60 produces identical state regardless
 of wall-clock time taken.
@@ -130,6 +131,39 @@ This is the deliverable that keeps the property from rotting.
 
 ---
 
+## Stage 6 — Headless contract
+
+Determinism is necessary but not sufficient for offline rendering. The system must
+also be *drivable from outside*, with no environmental dependencies.
+
+Consumers that step the library headlessly — in a Web Worker against an
+`OffscreenCanvas`, or under headless Chromium — are out of scope for this repo, but
+the contract that makes them possible is not.
+
+**Requirements:**
+
+- **The library never owns a loop.** No internal `requestAnimationFrame`. The caller
+  supplies `dt` and decides when to advance. (Verify in Stage 0 — this may already
+  hold.)
+- **No wall-clock reads in the sim path.** Covered by Stage 3, restated here because
+  it is the requirement that breaks headless stepping when violated.
+- **Simulation and rendering are separable.** A caller must be able to step N times
+  without rendering, or render the same state twice, in any order.
+- **No DOM access in the sim path.** No `document`, no `window`, no
+  `HTMLImageElement`. Textures arrive as decoded data via the resolver (05), not as
+  DOM elements. This is the requirement most likely to be quietly violated today.
+- **No `HTMLCanvasElement` assumption.** Anything canvas-shaped must accept an
+  `OffscreenCanvas`.
+
+**Acceptance:** a system steps 600 times inside a Web Worker with no DOM present,
+and produces particle state digests identical to the same run on the main thread.
+
+**Explicitly not this repo's job:** frame capture, sprite-sheet packing, video
+encoding, camera framing, warmup heuristics, loop-point selection, CLI, queueing.
+Those belong to whatever consumes this contract.
+
+---
+
 ## Known non-determinism sources to eliminate
 
 | Source | Fix |
@@ -149,6 +183,6 @@ netcode, not for this. Do not over-engineer.
 
 ## Explicitly out of scope
 
-- Cross-engine determinism (three-nebula ↔ some future Unity runtime)
+- Cross-runtime determinism (three-nebula ↔ a port to another engine)
 - Rewind / reverse simulation
 - Deterministic GPU simulation (revisit if/when a compute path exists)

--- a/specs/03-sound-renderer.md
+++ b/specs/03-sound-renderer.md
@@ -120,8 +120,9 @@ flanging mush. Two mitigations, both mandatory:
 - **Start-offset jitter** — a few ms of random offset into the buffer. Decorrelates
   transients even at identical pitch.
 
-Both must be deterministic. A bake must produce the same pitches. (Even though
-audio isn't in the bake today — see below — this keeps the property honest.)
+Both must be deterministic — the same system must produce the same pitches on
+every run. (Audio is not captured by offline rendering anyway — see below — but
+the property should hold regardless.)
 
 ---
 
@@ -140,7 +141,7 @@ is not a bug to work around; design for it:
 
 - Seeking / scrubbing (02, Stage 4)
 - `timeScale !== 1` (pitch would be wrong and it's not worth correcting)
-- The system is being baked headlessly
+- The system is being stepped headlessly (02, Stage 6)
 - `ctx.state !== "running"`
 
 **Clock note.** Web Audio's `currentTime` and rAF are different clocks. Spawning
@@ -170,9 +171,9 @@ concrete demands it.**
 
 ## Known limitations to document, not solve
 
-- **Baked export loses audio.** A sprite sheet has no audio track. A system with
-  sound only works fully in three-nebula. This means the sound feature and the
-  cross-engine baking story do not compose. Not fatal; be honest about it in docs.
+- **Offline rendering loses audio.** A sprite sheet has no audio track. A system
+  with a sound renderer renders silently, so sound and any sheet/video export path
+  do not compose. Not fatal; be explicit about it in the docs.
 - **No external mixer.** A native engine has audio middleware (Wwise, FMOD)
   downstream to arbitrate voice budgets, ducking and concurrency — engine
   integrations of FX tools typically defer to it, and PopcornFX's UE integration

--- a/specs/03-sound-renderer.md
+++ b/specs/03-sound-renderer.md
@@ -3,7 +3,7 @@
 Treat particles as sound sources. A renderer that emits voices instead of pixels.
 
 **Depends on:** 02 (seeded jitter, scrub muting), 05 (audio blob storage)
-**Priority:** lowest of the specs. Most additive, least entangled, easiest to defer.
+**Priority:** lowest of the six. Most additive, least entangled, easiest to defer.
 
 ---
 
@@ -16,8 +16,12 @@ The particle stays dumb — position, life, age, alpha, size. It has no idea it'
 audible. The *renderer* decides to interpret the stream as voices. Nothing new
 enters the particle struct. The simulation does not branch.
 
-This is PopcornFX's model (sound sits alongside billboard, mesh, ribbon, light,
-decal as a peer renderer) and it's the right one.
+Sound sits alongside billboard, mesh, ribbon and light as a peer renderer.
+
+*Prior art:* this is PopcornFX's model — its renderer list is billboard, mesh,
+ribbon, light, **sound**, decal, triangle, where the sound renderer simply treats
+particles as sound sources in the world. It's the right shape and worth copying
+closely.
 
 **Corollary:** a layer can carry both renderers. An ember that glows *and* crackles
 is one emitter with a `SpriteRenderer` and a `SoundRenderer` reading the same
@@ -90,12 +94,19 @@ Three independent throttles, all needed:
    effective control. 500 sparks, 5% probability → 25 crackles. Sounds right,
    costs nothing.
 
-**Priority heuristic warning.** PopcornFX prioritises by volume × attenuation and
-their own docs concede the heuristic is naive: it reads the *configured* volume,
-not perceived loudness, so a quiet sample at volume 1.0 beats a hot sample at 0.1.
-Their guidance is to normalise your audio so the heuristic works.
+**Priority heuristic warning.** The obvious voice-stealing heuristic — rank by
+`volume × attenuation` — is naive, and it's worth understanding why before
+shipping it. It reads the *configured* volume, not perceived loudness: a quiet
+sample at volume 1.0 outranks a hot sample at 0.1, which is backwards.
 
-Do the same, and **say so in the docs**. Do not attempt loudness analysis in v1.
+The pragmatic answer is to use the heuristic anyway and require **normalised
+source audio** (all samples at roughly equal perceptual loudness), then **say so
+in the docs**. Do not attempt loudness analysis in v1.
+
+*Prior art:* PopcornFX prioritises exactly this way, and its docs are refreshingly
+candid that the heuristic misjudges for precisely this reason — their guidance is
+to normalise source audio so it behaves. Their sound renderer page is worth reading
+before implementing this stage.
 
 ---
 
@@ -122,8 +133,8 @@ is not a bug to work around; design for it:
 - The system must function fully with audio unavailable. Sound is decoration on
   a working sim, never a dependency.
 - Expose `system.audio.resume()` for the host to call from a click handler.
-- Editor: sound off until the user presses play. Gallery: **silent on hover,
-  sound on click.** Nobody wants a grid of screaming thumbnails.
+- Default to silence; opt in on an explicit user action. Any consumer displaying
+  many systems at once must not auto-play audio.
 
 **Mute conditions** — the renderer must not fire when:
 
@@ -143,12 +154,17 @@ with lookahead — do not do this now.
 
 A sound that travels with a particle and stops on its death. Requires holding a
 handle per voice, updating the panner in `onParticleUpdate`, and stopping in
-`onParticleDead`. Niagara splits exactly this way — `Play Audio` (one-shot, cheap,
-uncancellable) vs `Play Persistent Audio` (retains a reference so it can be
-updated, needs a paired update module, trickier to set up).
+`onParticleDead`.
 
-Their split is a good signal: the persistent path is meaningfully harder and most
-effects don't need it. **Do not build this until something concrete demands it.**
+*Prior art:* Niagara splits exactly here. `Play Audio` is the one-shot — cheapest,
+fires and forgets, and once triggered it cannot be changed or stopped and keeps
+playing even if the simulation does not. `Play Persistent Audio` retains a
+reference per voice so it can be updated over time, requires a paired update
+module, and is notably trickier to set up.
+
+That two-feature split is a good signal: the persistent path is meaningfully
+harder and most effects don't need it. **Do not build this until something
+concrete demands it.**
 
 ---
 
@@ -157,11 +173,10 @@ effects don't need it. **Do not build this until something concrete demands it.*
 - **Baked export loses audio.** A sprite sheet has no audio track. A system with
   sound only works fully in three-nebula. This means the sound feature and the
   cross-engine baking story do not compose. Not fatal; be honest about it in docs.
-- **Licensing surface.** Audio has a messier provenance landscape than textures —
-  someone uploading a sound ripped from a game is both more likely and more
-  actionable than a stolen gradient. 05's content-addressing is what makes this
-  auditable. Flag it to whoever writes the gallery upload terms.
-- **No mixer.** There is no Wwise/FMOD on the web, so a self-contained effect is
-  more valuable here than it would be in AAA (where audio directors reasonably
-  object to VFX spawning unbudgeted voices outside their concurrency rules).
-  That asymmetry is the reason this feature is worth building at all.
+- **No external mixer.** A native engine has audio middleware (Wwise, FMOD)
+  downstream to arbitrate voice budgets, ducking and concurrency — engine
+  integrations of FX tools typically defer to it, and PopcornFX's UE integration
+  has you configure max concurrency per sound asset for exactly this reason. On the
+  web there is nothing downstream. The library owns its own voice budget, which is
+  why the limiting in Stage 2 is the substance of this spec rather than an
+  optimisation.

--- a/specs/03-sound-renderer.md
+++ b/specs/03-sound-renderer.md
@@ -1,0 +1,167 @@
+# Spec 03 — Sound Renderer
+
+Treat particles as sound sources. A renderer that emits voices instead of pixels.
+
+**Depends on:** 02 (seeded jitter, scrub muting), 05 (audio blob storage)
+**Priority:** lowest of the specs. Most additive, least entangled, easiest to defer.
+
+---
+
+## The model
+
+**This is not a sound-type particle.** It is an ordinary particle that a sound
+renderer happens to be reading.
+
+The particle stays dumb — position, life, age, alpha, size. It has no idea it's
+audible. The *renderer* decides to interpret the stream as voices. Nothing new
+enters the particle struct. The simulation does not branch.
+
+This is PopcornFX's model (sound sits alongside billboard, mesh, ribbon, light,
+decal as a peer renderer) and it's the right one.
+
+**Corollary:** a layer can carry both renderers. An ember that glows *and* crackles
+is one emitter with a `SpriteRenderer` and a `SoundRenderer` reading the same
+particles. No duplicate emitter.
+
+**Corollary 2:** triggering is already built. "Play a sound 0.5s in" is an emitter
+with `delay: 0.5`, `burst: 1`, `life: <sound duration>`, and a sound renderer. It
+draws nothing. It exists to be heard. The existing rate/burst/delay controls *are*
+the sound sequencer.
+
+---
+
+## Stage 0 — Audit
+
+1. Exact renderer interface — confirm the lifecycle hooks. Assumed:
+   `onParticleCreated`, `onParticleUpdate`, `onParticleDead`, `onSystemUpdate`.
+2. Is there any existing audio anywhere in the codebase? (Assume no.)
+3. How does the system expose the camera? The audio listener must track it.
+
+---
+
+## Stage 1 — One-shot voices
+
+**v1 is one-shot only.** Fire and forget. Persistent/attached sounds are Stage 5
+and may never happen.
+
+```
+onParticleCreated(particle):
+  if (!canPlay()) return          // voice cap, cooldown, probability
+  const src = ctx.createBufferSource()
+  src.buffer = resolvedBuffer
+  src.detune.value = jitter(particle.prng, detuneRange)
+  src.connect(panner).connect(gain).connect(ctx.destination)
+  src.start(ctx.currentTime, startOffsetJitter(particle.prng))
+```
+
+That's it. No handle retained. The voice finishes and GCs itself.
+
+**Config on the renderer (not the particle):**
+
+```jsonc
+{
+  "type": "sound",
+  "src": { "$ref": "sha256:..." },
+  "volume": 0.8,
+  "detuneCents": [-200, 200],
+  "startOffsetMs": [0, 30],
+  "maxVoices": 8,
+  "cooldownMs": 40,
+  "probability": 0.2,
+  "attenuation": { "refDistance": 1, "maxDistance": 50, "rolloff": 1 },
+  "gainFrom": "alpha",        // optional particle attribute → gain
+  "pitchFrom": null
+}
+```
+
+---
+
+## Stage 2 — Voice limiting
+
+**This is the feature.** 500 sparks × a sound renderer = 500 voices = catastrophe.
+
+Three independent throttles, all needed:
+
+1. **`maxVoices`** — hard cap per renderer. When exceeded, steal the
+   lowest-priority live voice or drop the new one (drop is usually better for FX).
+2. **`cooldownMs`** — minimum gap between triggers on this renderer. Kills the
+   machine-gun case where 50 particles spawn in one frame.
+3. **`probability`** — play on only N% of particles. The cheapest and most
+   effective control. 500 sparks, 5% probability → 25 crackles. Sounds right,
+   costs nothing.
+
+**Priority heuristic warning.** PopcornFX prioritises by volume × attenuation and
+their own docs concede the heuristic is naive: it reads the *configured* volume,
+not perceived loudness, so a quiet sample at volume 1.0 beats a hot sample at 0.1.
+Their guidance is to normalise your audio so the heuristic works.
+
+Do the same, and **say so in the docs**. Do not attempt loudness analysis in v1.
+
+---
+
+## Stage 3 — Jitter (required, not polish)
+
+Many copies of the same sample within a few milliseconds phase-cancel into
+flanging mush. Two mitigations, both mandatory:
+
+- **Detune jitter** — per-voice `detune` in cents, drawn from the *particle's*
+  seeded PRNG (02). Suggest ±200 cents default.
+- **Start-offset jitter** — a few ms of random offset into the buffer. Decorrelates
+  transients even at identical pitch.
+
+Both must be deterministic. A bake must produce the same pitches. (Even though
+audio isn't in the bake today — see below — this keeps the property honest.)
+
+---
+
+## Stage 4 — Context lifecycle and scrub
+
+**Autoplay policy.** `AudioContext` starts `suspended` until a user gesture. This
+is not a bug to work around; design for it:
+
+- The system must function fully with audio unavailable. Sound is decoration on
+  a working sim, never a dependency.
+- Expose `system.audio.resume()` for the host to call from a click handler.
+- Editor: sound off until the user presses play. Gallery: **silent on hover,
+  sound on click.** Nobody wants a grid of screaming thumbnails.
+
+**Mute conditions** — the renderer must not fire when:
+
+- Seeking / scrubbing (02, Stage 4)
+- `timeScale !== 1` (pitch would be wrong and it's not worth correcting)
+- The system is being baked headlessly
+- `ctx.state !== "running"`
+
+**Clock note.** Web Audio's `currentTime` and rAF are different clocks. Spawning
+voices off rAF gives up to ~16ms jitter. That is tolerable for FX and not worth
+fixing in v1. If anything rhythmic ever matters, schedule against `ctx.currentTime`
+with lookahead — do not do this now.
+
+---
+
+## Stage 5 — Persistent voices (deferred, possibly never)
+
+A sound that travels with a particle and stops on its death. Requires holding a
+handle per voice, updating the panner in `onParticleUpdate`, and stopping in
+`onParticleDead`. Niagara splits exactly this way — `Play Audio` (one-shot, cheap,
+uncancellable) vs `Play Persistent Audio` (retains a reference so it can be
+updated, needs a paired update module, trickier to set up).
+
+Their split is a good signal: the persistent path is meaningfully harder and most
+effects don't need it. **Do not build this until something concrete demands it.**
+
+---
+
+## Known limitations to document, not solve
+
+- **Baked export loses audio.** A sprite sheet has no audio track. A system with
+  sound only works fully in three-nebula. This means the sound feature and the
+  cross-engine baking story do not compose. Not fatal; be honest about it in docs.
+- **Licensing surface.** Audio has a messier provenance landscape than textures —
+  someone uploading a sound ripped from a game is both more likely and more
+  actionable than a stolen gradient. 05's content-addressing is what makes this
+  auditable. Flag it to whoever writes the gallery upload terms.
+- **No mixer.** There is no Wwise/FMOD on the web, so a self-contained effect is
+  more valuable here than it would be in AAA (where audio directors reasonably
+  object to VFX spawning unbudgeted voices outside their concurrency rules).
+  That asymmetry is the reason this feature is worth building at all.

--- a/specs/03-sound-renderer.md
+++ b/specs/03-sound-renderer.md
@@ -3,7 +3,7 @@
 Treat particles as sound sources. A renderer that emits voices instead of pixels.
 
 **Depends on:** 02 (seeded jitter, scrub muting), 05 (audio blob storage)
-**Priority:** lowest of the six. Most additive, least entangled, easiest to defer.
+**Priority:** lowest of the five. Most additive, least entangled, easiest to defer.
 
 ---
 

--- a/specs/04-schema-versioning.md
+++ b/specs/04-schema-versioning.md
@@ -1,0 +1,140 @@
+# Spec 04 — Schema Versioning
+
+A `version` field and a migration chain, so the schema can change without
+stranding six years of saved systems.
+
+**Blocks:** 01 (hierarchy), 05 (assets) — both break the schema.
+**Size:** small. Boring. Lands first.
+
+---
+
+## Why first
+
+01 turns `emitters[]` into a tree. 05 replaces inlined base64 with hash refs.
+Both are breaking changes to the JSON.
+
+There are systems in the wild right now — six years of them, in Discords, in
+gists, in people's projects. If a new three-nebula rejects them, the goodwill
+that survived six years of dormancy does not survive that.
+
+This spec is the escape hatch that makes every later schema change cheap. It must
+exist before the first one lands, not after.
+
+---
+
+## Stage 0 — Audit
+
+1. Does the JSON have any version marker today? Any at all?
+2. What does `System.fromJSON` / `fromJSONAsync` do on unrecognised fields —
+   throw, ignore, or crash?
+3. Are there existing JSON fixtures in the test suite? How many? Are they
+   representative?
+4. Is the JSON schema documented anywhere authoritative, or is the parser the spec?
+
+---
+
+## Stage 1 — The field
+
+```jsonc
+{
+  "version": 2,
+  "emitters": [ /* ... */ ]
+}
+```
+
+**Integer, monotonic. Not semver.** Semver invites debate about what counts as a
+minor change. An integer that increments whenever the shape changes has no
+ambiguity and the migration chain is trivially ordered.
+
+Rules:
+
+- **Missing `version` → treat as `0`** (legacy, pre-versioning). This is the
+  entire back-compat story for existing content and it must never be removed.
+- **`version` > current → clear, actionable error.** Not a crash, not silent
+  partial parse. `"This system was created with a newer version of three-nebula
+  (v5). This build supports up to v3. Update three-nebula."`
+- **`version` < current → run the migration chain.**
+
+---
+
+## Stage 2 — Migration registry
+
+```js
+const migrations = {
+  0: migrate0to1,   // legacy → versioned
+  1: migrate1to2,   // flat emitters → tree (spec 01)
+  2: migrate2to3,   // base64 textures → hash refs (spec 05)
+};
+
+function migrate(json) {
+  let v = json.version ?? 0;
+  while (v < CURRENT_VERSION) {
+    json = migrations[v](json);
+    v += 1;
+    json.version = v;
+  }
+  return json;
+}
+```
+
+Requirements:
+
+- Each migration is a **pure function**: JSON in, JSON out. No side effects, no
+  network, no I/O. (05 needs async blob writes — see that spec for how it splits
+  the pure transform from the storage step.)
+- Migrations are **append-only**. Once shipped, a migration is frozen forever.
+  Never edit a released migration; add a new one.
+- `System.fromJSON` runs `migrate()` before anything else touches the object.
+- Migrations must be individually unit-testable without instantiating a system.
+
+---
+
+## Stage 3 — The fixture corpus
+
+This is what stops the guarantee from rotting.
+
+- Collect **real** legacy JSON. Not synthesised — actual systems from the repo's
+  examples, the docs site, and (if you can get them) from users. Ask in the
+  Discords; people will send you their old files and it's a nice re-engagement
+  excuse.
+- Store under `test/fixtures/schema/v0/`, `v1/`, etc.
+- Golden test: every fixture at every version loads without error and produces
+  a system whose structure matches an expected snapshot.
+- **Add a fixture for every version, at the time that version ships.** A v2
+  fixture written after v4 exists is not evidence of anything.
+
+**Acceptance:** CI fails if any historical fixture stops loading.
+
+---
+
+## Stage 4 — Write path
+
+- `System.toJSON()` always emits the current version. Never write old versions.
+- No "save as v1" affordance. Downgrade is not a supported operation and
+  pretending otherwise creates an infinite matrix.
+- The editor's export always produces current-version JSON.
+
+---
+
+## Interaction with 01 and 05
+
+The migration for **01** (flat → tree) is mechanical: wrap each existing emitter
+with `children: []`. Every legacy system is a tree of depth 1. Lossless.
+
+The migration for **05** (base64 → refs) is *not* purely mechanical, because it
+must write blobs somewhere. The pure transform can only rewrite the reference;
+the blob extraction needs a storage target. See 05, Stage 3 — the resolution is
+that the migration emits an intermediate form carrying the decoded bytes, and the
+asset store consumes it.
+
+Do not let 05's awkwardness leak into this spec's design. Migrations stay pure;
+05 adapts.
+
+---
+
+## Explicitly out of scope
+
+- Downgrade / backward migration
+- Schema validation (JSON Schema, zod, etc.) — worth doing, separate concern,
+  do not couple it to versioning
+- Versioning the *bundle* format (05's container) — related but distinct

--- a/specs/05-content-addressed-assets.md
+++ b/specs/05-content-addressed-assets.md
@@ -1,0 +1,288 @@
+# Spec 05 — Content-Addressed Assets
+
+Replace inlined base64 textures with content-addressed references, plus a
+pluggable resolver and a bundle container.
+
+**Depends on:** 04 (schema versioning) — this breaks the schema.
+**Blocks:** 03 (audio blob storage)
+
+---
+
+## Context: the current design was correct
+
+Textures are currently base64-encoded directly into the system JSON. **This was
+the right call.** Nebula was an NW.js desktop app with no server: one portable
+file, no asset resolution, no CORS, atomically versioned, works offline.
+
+The constraint has changed, not the reasoning. Any consumer holding more than a
+handful of systems needs dedup, CDN caching, and stable asset identity — none of
+which are possible when assets are anonymous strings inside documents.
+
+**Do not frame this as fixing a mistake. It's an inherited constraint being lifted.**
+
+---
+
+## What breaks at scale
+
+| Problem | Consequence |
+|---|---|
+| No dedup | The same dozen smoke puffs stored once per system. 500 systems = 500 copies. |
+| No CDN caching | Texture bytes ride inside the JSON; every fetch re-downloads them. Nothing is reusable across systems. |
+| Flipbooks | A 4K 8×8 sheet is several MB raw, ~33% more base64'd. `JSON.parse` on a 10MB blob stalls the main thread. |
+| No asset identity | Two systems using the same texture are unrelatable. "What uses this asset?" is unanswerable. |
+| Useless diffs | Any texture tweak rewrites the whole document. |
+
+Asset identity is the one with no workaround. With a content hash, "what uses
+this?" is a single lookup; with inlined base64 the question cannot be asked.
+
+## Precedent
+
+glTF ships exactly these three forms of the same problem:
+
+- `.gltf` + external files → references
+- `.gltf` with `data:` URIs → **the current design**
+- `.glb` → binary container, JSON chunk + binary chunk, no base64
+
+The industry converged on GLB, for precisely the 33% tax plus parse cost. Steal
+the resolution, not just the problem statement — and lean on it in docs, because
+three.js users already know this shape.
+
+---
+
+## Stage 0 — Audit
+
+1. How are textures currently represented in the JSON? Exact field paths.
+2. Is base64 the only form, or are URLs also accepted?
+3. Where does texture loading happen — is there a single choke point or is it
+   scattered across renderers/initializers?
+4. Is `Body` / sprite texture handling shared with anything else?
+5. Is there any caching of decoded textures today?
+
+---
+
+## Stage 1 — Reference format
+
+```jsonc
+{
+  "renderer": {
+    "type": "sprite",
+    "texture": { "$ref": "sha256:a3f2c1..." }
+  }
+}
+```
+
+- **sha256 over the raw bytes**, hex-encoded, prefixed with the algorithm.
+  The prefix is cheap and buys algorithm agility.
+- The hash **is** the identity. Immutable by construction.
+- Same format for audio blobs (03) and any future asset type. One store.
+
+---
+
+## Stage 2 — Resolver interface
+
+The runtime must not know or care where bytes come from.
+
+```ts
+interface AssetResolver {
+  resolve(ref: string): Promise<ArrayBuffer>;
+  has(ref: string): boolean;
+}
+```
+
+Implementations:
+
+- `MemoryResolver` — a `Map`, for tests and for the embed case
+- `BundleResolver` — reads from an unpacked container (Stage 4)
+- `HttpResolver` — `GET {baseUrl}/{hash}`, immutable cache semantics
+- `IndexedDBResolver` — browser-local persistence
+- `ChainResolver` — tries several in order
+
+**Decoded-texture cache keyed by hash.** This is where dedup actually pays: a
+thousand systems referencing the same gradient decode it once.
+
+---
+
+## Stage 3 — Migration from base64
+
+04 requires migrations to be pure functions. Blob extraction needs a storage
+target. The resolution:
+
+- The **pure** migration rewrites `"data:image/png;base64,..."` →
+  `{ "$ref": "sha256:..." }` and emits the decoded bytes into a side-channel on
+  the returned object (`__pendingAssets: Map<ref, ArrayBuffer>`).
+- `System.fromJSON` (which is already async) drains `__pendingAssets` into
+  whatever resolver it was given, then discards the side-channel.
+- Migrations stay pure. The async lives at the call site where it belongs.
+
+**Back-compat is permanent.** Keep accepting `data:` URIs and plain URLs forever;
+normalise to refs on read. Legacy systems must keep loading with no ceremony.
+
+---
+
+## Stage 4 — Bundle container
+
+A system plus every asset it references, as one portable file. This is what makes
+a system genuinely self-contained: a JSON whose textures live on somebody else's
+server is not portable, it's a dangling dependency.
+
+*Prior art:* Effekseer's `.efkpkg` does exactly this — an effect bundled with every
+resource it references, travelling as one artifact. glTF's `.glb` is the same idea
+in a container three.js users already know.
+
+Two viable shapes:
+
+- **Zip** — trivially inspectable, universal tooling, streams poorly.
+- **GLB-style binary container** — JSON chunk + blob chunk, fast to parse,
+  requires custom tooling.
+
+**Recommend zip for v1.** Deflate on already-compressed PNGs is near-free; store
+them uncompressed. Universal tooling matters more than parse speed at this stage,
+and the format is versioned separately from the schema (04) so it can change.
+
+```
+system.nebula (zip)
+├── manifest.json     { bundleVersion, systemRef, assets: [{ ref, mime, bytes }] }
+├── system.json       (version-stamped, refs only)
+└── assets/
+    ├── a3f2c1...     (raw bytes, filename = hash)
+    └── 9b7e04...
+```
+
+**Verify hashes on read.** A ref that doesn't match its bytes is a corrupt or
+tampered bundle and should fail loudly.
+
+---
+
+## Stage 5 — Export modes
+
+There are **three** export modes and they are not interchangeable. The bundle
+(Stage 4) is the default. Base64 is a narrow third path, not the export format.
+
+| Mode | Output | Use | Assets |
+|---|---|---|---|
+| `bundle` **(default)** | `.nebula` zip | Distributing a system to anyone else | Packed, hash-verified |
+| `refs` | `system.json` + loose asset files | A build pipeline where the bundler/CDN handles assets | External |
+| `embed` | one `system.json` | Copy-paste into a CodePen/gist, single-file demo, no build step | `data:` URIs |
+
+**Why `bundle` beats `embed` almost everywhere:** a zip is *also* one
+self-contained portable file. It just doesn't pay the ~33% base64 tax or the
+`JSON.parse` cost on a multi-MB string. Anywhere the goal is "one file I can hand
+someone," `bundle` is strictly better.
+
+**`embed`'s only real advantage is pasteability.** A zip cannot be pasted into a
+text editor. That is a genuine use case — plausibly how a lot of three.js
+developers first try the library — so the mode stays and should be a first-class,
+documented affordance. It is not the default and it is not the storage format.
+
+**Guard rail:** `embed` should warn (not fail) above a size threshold — suggest
+2MB of decoded assets. The moment flipbooks are involved, `embed` stops being
+viable and users should be told why rather than discovering it as a mystery stall.
+
+Keep base64 as an **explicit opt-in export flag**, not the canonical form.
+
+```js
+system.toBundle()                      // .nebula zip (default for sharing)
+system.toJSON()                        // refs (default for build pipelines)
+system.toJSON({ embedAssets: true })   // data: URIs, one self-contained file
+```
+
+---
+
+## Stage 6 — Runtime & distribution
+
+**The bundle is an interchange format, not a runtime format.** Nothing should
+ship a zip to production. This is the single most important thing in this spec to
+get right, and it is currently only implied by the resolver interface.
+
+| Phase | Format | Who handles it |
+|---|---|---|
+| **Interchange** | `.nebula` zip | Publishing, downloading, handing a file to a colleague |
+| **Build** | unpacked → `system.json` + loose assets | The bundler |
+| **Runtime** | refs resolved to URLs | The app |
+
+The zip exists to move a system from A to B intact. It is unpacked **once, at
+build time**, and never appears in production — the same way nobody ships a zip
+of `node_modules`.
+
+### Why runtime-unzip is actively wrong on the web
+
+- **HTTP caching dies.** A zip is one opaque blob. Change one texture and the
+  whole thing redownloads. Loose hashed assets cache individually, forever.
+- **No parallel fetch.** The browser will pull six textures concurrently. A zip
+  is one serial request, then a decompress.
+- **Main-thread cost** for the unzip, on every load.
+- **No transcoding.** Consumers may want webp/avif, or KTX2 for GPU textures.
+  You cannot run an image pipeline over bytes sealed in a zip.
+- **No code splitting.** The system can't be lazily loaded per-route if it's
+  welded into a blob.
+
+### Consumer paths
+
+**With a build pipeline (Vite/Next/webpack — the common case).**
+
+Their bundler *already does content-addressing*: it emits `fire-tex.a3f2c1.png`
+with immutable cache headers. Our hash refs map onto that almost exactly.
+
+Ship a **bundler plugin** (`@nebula/vite-plugin`, others later):
+
+```js
+import fireSystem from './effects/fire.nebula'
+// → unpacked at build, assets emitted through Vite's pipeline,
+//   refs resolved to hashed URLs, tree-shaken, lazy-loadable
+```
+
+Architecturally this is nearly free: the plugin constructs an `AssetResolver`
+(Stage 2) backed by the bundler's emitted URLs. Small package, high DX leverage.
+
+**Without a build step** — Webflow, a CMS, a marketing site, a `<script>` tag.
+
+This is where `embed` (Stage 5) earns its keep. One JSON, base64 assets, no asset
+pipeline to configure, no CORS. For an agency dropping one hero effect onto a
+landing page with no tooling, this is the correct answer.
+
+**CDN-hosted refs** — viable for a live web page (`HttpResolver`, immutable cache
+keys). **Never for a shipped game**: offline breaks, latency, CORS, a GDPR
+surface from player IPs, and a hard dependency on our uptime. Document it as
+demo/web-embed convenience only, with no SLA.
+
+### Hard architectural constraint
+
+**three-nebula core must never contain a zip decoder.**
+
+Bundle handling lives in a separate package — `@nebula/bundle` — consumed by the
+editing tools, packaging tools, and the bundler plugin. The runtime only ever
+accepts an `AssetResolver`.
+
+This keeps the core small, keeps fflate (or equivalent) out of every consumer's
+bundle, and means the zip-vs-GLB decision in Stage 4 can be revisited later
+without touching the runtime at all.
+
+It also validates the Stage 2 resolver design: `HttpResolver` covers
+agency-with-CDN, `MemoryResolver` covers embed, the bundler plugin covers the
+build case — and none of them require the runtime to know that a bundle format
+exists.
+
+---
+
+## Downstream (not this spec — just don't foreclose it)
+
+Content-addressing makes several things tractable that are impossible while assets
+are anonymous strings inside documents:
+
+- **Shared asset libraries** — curated packs; "what uses this texture?" as a
+  query; one asset becoming a dependency of many systems.
+- **Programmatic system generation** — with a tagged, hashed asset store, asset
+  selection becomes *retrieval* rather than *generation*.
+- **Asset-level metadata** — licensing, attribution and provenance attach to the
+  hash once, rather than to every copy.
+
+Nothing in this spec builds any of that. It only needs to avoid ruling it out.
+
+---
+
+## Explicitly out of scope
+
+- Any specific storage backend — that's infrastructure, not runtime
+- Texture tagging / search
+- Licensing metadata schema — flag that it will attach to the hash, then leave it
+- Compression / transcoding (KTX2, basis) — real future win, separate spec

--- a/specs/README.md
+++ b/specs/README.md
@@ -2,8 +2,7 @@
 
 ## Purpose
 
-Six specs covering the runtime work needed before the web editor and social gallery
-can be built on top of three-nebula.
+Six specs covering runtime modernisation work for the three-nebula library.
 
 **The numbers are identifiers, not execution order.** See the dependency graph below.
 
@@ -48,6 +47,16 @@ Suggested landing order: **04 → 02 → 01 → 05 → 06 → 03**
 03 (sound) is deliberately last: it is the most additive and least entangled,
 and it is the easiest to defer if time runs short.
 
+## On prior art
+
+Several specs cite existing FX tools — PopcornFX, Niagara, Effekseer, glTF — where
+they solved a problem first and solved it well. These are **references, not
+comparisons**: the point is to learn from work that's already been done rather than
+rediscover it, and to give an implementer somewhere concrete to read.
+
+Where a design here differs from prior art, that's a deliberate choice and the
+reasoning is stated. Where it copies, that's also deliberate.
+
 ## Assumptions flagged for verification
 
 These specs were written without repo access. Every spec contains an
@@ -66,6 +75,6 @@ If the audits contradict a spec, **trust the repo**.
 
 ## Out of scope
 
-- Editor work (the NW.js → browser port)
-- Gallery / backend / auth
-- Anything to do with pricing or Pro tiering
+- Anything outside the three-nebula library itself
+- Applications built on top of the library
+- Backend, hosting, or distribution infrastructure

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,71 @@
+# three-nebula Modernisation — Spec Index
+
+## Purpose
+
+Six specs covering the runtime work needed before the web editor and social gallery
+can be built on top of three-nebula.
+
+**The numbers are identifiers, not execution order.** See the dependency graph below.
+
+## Specs
+
+| # | Spec | Shape |
+|---|------|-------|
+| 01 | Emitter Hierarchy (nested emitters, ribbon/trail renderer, pooling) | New capability + schema break |
+| 02 | Determinism & Scrubbing | Architecture, invisible, blocking |
+| 03 | Sound Renderer | New capability, additive |
+| 04 | Schema Versioning | Architecture, enabling |
+| 05 | Content-Addressed Assets | Architecture + schema break |
+| 06 | Baking | New subsystem, sits above runtime |
+
+## Dependency graph
+
+```
+04 (versioning) ──┬──> 01 (hierarchy)  ──> 06 (baking)
+                  │         ▲                  ▲
+                  └──> 05 (assets)             │
+                            ▲                  │
+02 (determinism) ───────────┴──────────────────┘
+                            │
+                            └──> 03 (sound)
+```
+
+**Hard constraints:**
+
+- **04 lands first.** Both 01 and 05 break the JSON schema. Without a migration
+  path in place, every existing saved system is stranded. 04 is small and boring
+  and must precede both.
+- **02 entangles with 01.** Child emitter instances need seeds derived from the
+  parent particle's ID. Landing 01 without 02 means touching every initializer
+  and behaviour twice.
+- **06 depends on 02.** A non-deterministic sim cannot be baked reproducibly —
+  the thumbnail won't match the preview, and two bakes of the same system differ.
+- **03 depends on 02** for jitter (pitch/offset randomisation must be seeded) and
+  on **05** for audio blob storage.
+
+Suggested landing order: **04 → 02 → 01 → 05 → 06 → 03**
+
+03 (sound) is deliberately last: it is the most additive and least entangled,
+and it is the easiest to defer if time runs short.
+
+## Assumptions flagged for verification
+
+These specs were written without repo access. Every spec contains an
+**Audit** stage as Stage 0. Claude Code should run those audits first and
+correct the specs before implementation. In particular, the following are
+**guesses** and may already be solved:
+
+- Whether particle pooling exists and how it works
+- Whether a seeded PRNG exists, or whether `Math.random()` is called directly
+- Whether particles carry a stable ID
+- Whether flipbook / sprite-sheet playback already exists in some form
+- The current renderer interface's exact lifecycle hooks
+- Whether the sim uses a fixed timestep or raw delta
+
+If the audits contradict a spec, **trust the repo**.
+
+## Out of scope
+
+- Editor work (the NW.js → browser port)
+- Gallery / backend / auth
+- Anything to do with pricing or Pro tiering

--- a/specs/README.md
+++ b/specs/README.md
@@ -15,18 +15,15 @@ Six specs covering runtime modernisation work for the three-nebula library.
 | 03 | Sound Renderer | New capability, additive |
 | 04 | Schema Versioning | Architecture, enabling |
 | 05 | Content-Addressed Assets | Architecture + schema break |
-| 06 | Baking | New subsystem, sits above runtime |
 
 ## Dependency graph
 
 ```
-04 (versioning) ──┬──> 01 (hierarchy)  ──> 06 (baking)
-                  │         ▲                  ▲
-                  └──> 05 (assets)             │
-                            ▲                  │
-02 (determinism) ───────────┴──────────────────┘
-                            │
-                            └──> 03 (sound)
+04 (versioning) ──┬──> 01 (hierarchy)
+                  │         ▲
+                  └──> 05 (assets)
+                            ▲
+02 (determinism) ───────────┴──> 03 (sound)
 ```
 
 **Hard constraints:**
@@ -37,12 +34,10 @@ Six specs covering runtime modernisation work for the three-nebula library.
 - **02 entangles with 01.** Child emitter instances need seeds derived from the
   parent particle's ID. Landing 01 without 02 means touching every initializer
   and behaviour twice.
-- **06 depends on 02.** A non-deterministic sim cannot be baked reproducibly —
-  the thumbnail won't match the preview, and two bakes of the same system differ.
 - **03 depends on 02** for jitter (pitch/offset randomisation must be seeded) and
   on **05** for audio blob storage.
 
-Suggested landing order: **04 → 02 → 01 → 05 → 06 → 03**
+Suggested landing order: **04 → 02 → 01 → 05 → 03**
 
 03 (sound) is deliberately last: it is the most additive and least entangled,
 and it is the easiest to defer if time runs short.
@@ -78,3 +73,8 @@ If the audits contradict a spec, **trust the repo**.
 - Anything outside the three-nebula library itself
 - Applications built on top of the library
 - Backend, hosting, or distribution infrastructure
+- **Offline rendering / baking.** Stepping a system headlessly and encoding the
+  frames to sheets or video is a *consumer* of this library, not a feature of it:
+  it needs `reset()`, `step()` and determinism (02) and nothing else from the
+  runtime. The rest is three.js, canvas and WebCodecs. The library's only
+  obligation is the headless contract in **02, Stage 6**.

--- a/specs/README.md
+++ b/specs/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Six specs covering runtime modernisation work for the three-nebula library.
+Five specs covering runtime modernisation work for the three-nebula library.
 
 **The numbers are identifiers, not execution order.** See the dependency graph below.
 


### PR DESCRIPTION
Adds a `specs/` directory documenting the runtime modernisation work planned for
the library, ahead of implementation. **Documentation only — no runtime code.**

Each spec opens with a **Stage 0 — Audit** to be run against the repo first; the
specs were written without repo access and flag their assumptions (pooling, seeded
PRNG, particle IDs, renderer lifecycle hooks, fixed-vs-raw timestep) for
verification. Where the audit contradicts a spec, trust the repo.

## Specs

| # | Spec | Shape |
|---|------|-------|
| 01 | Emitter Hierarchy — nested child emitters, ribbon/trail renderers, pooling | New capability + schema break |
| 02 | Determinism & Scrubbing — seeded PRNG, fixed timestep, seek, headless contract | Architecture, blocking |
| 03 | Sound Renderer — particles as sound sources, voice limiting | New capability, additive |
| 04 | Schema Versioning — `version` field + migration chain | Architecture, enabling |
| 05 | Content-Addressed Assets — hash refs, resolver interface, bundle container | Architecture + schema break |

See `specs/README.md` for the dependency graph and hard constraints. Suggested
landing order: **04 → 02 → 01 → 05 → 03**.

Offline rendering / baking is intentionally **out of scope** — it's a consumer of
the library (needs only `reset()`, `step()`, determinism, and the Stage 6 headless
contract in spec 02), not a runtime feature.