### PR TITLE
Read emitter damping from JSON in fromJSON/fromJSONAsync

### DIFF
--- a/src/core/fromJSON.js
+++ b/src/core/fromJSON.js
@@ -2,6 +2,7 @@ import * as Behaviour from '../behaviour';
 import * as Initializer from '../initializer';
 
 import { EULER, POOL_MAX } from '../constants';
+import { DEFAULT_DAMPING } from '../emitter/constants';
 import {
   INITIALIZER_TYPES_THAT_REQUIRE_THREE,
   SUPPORTED_JSON_BEHAVIOUR_TYPES,
@@ -104,8 +105,10 @@ export default (json, THREE, System, Emitter) => {
       position,
       totalEmitTimes = Infinity,
       life = Infinity,
+      damping = DEFAULT_DAMPING,
     } = data;
 
+    emitter.damping = damping;
     emitter
       .setRate(makeRate(rate))
       .setRotation(rotation)

--- a/src/core/fromJSONAsync.js
+++ b/src/core/fromJSONAsync.js
@@ -2,6 +2,7 @@ import * as Behaviour from '../behaviour';
 import * as Initializer from '../initializer';
 
 import { EULER, POOL_MAX } from '../constants';
+import { DEFAULT_DAMPING } from '../emitter/constants';
 import {
   INITIALIZER_TYPES_THAT_REQUIRE_THREE,
   SUPPORTED_JSON_BEHAVIOUR_TYPES,
@@ -156,8 +157,10 @@ const makeEmitters = (emitters, Emitter, THREE, shouldAutoEmit) =>
         position,
         totalEmitTimes = Infinity,
         life = Infinity,
+        damping = DEFAULT_DAMPING,
       } = data;
 
+      emitter.damping = damping;
       emitter
         .setRate(makeRate(rate))
         .setRotation(rotation)

--- a/test/core/fromJSON.spec.js
+++ b/test/core/fromJSON.spec.js
@@ -25,6 +25,31 @@ describe('fromJSON', () => {
 
   });
 
+  const emitterWith = props => ({
+    emitters: [
+      {
+        rate: { particlesMin: 1, particlesMax: 1, perSecondMin: 1, perSecondMax: 1 },
+        rotation: { x: 0, y: 0, z: 0 },
+        position: { x: 0, y: 0, z: 0 },
+        initializers: [],
+        behaviours: [],
+        ...props,
+      },
+    ],
+  });
+
+  it('should read the emitter damping from JSON', () => {
+    const system = Particles.fromJSON(emitterWith({ damping: 0.02 }), THREE);
+
+    assert.strictEqual(system.emitters[0].damping, 0.02);
+  });
+
+  it('should default the emitter damping when it is absent from JSON', () => {
+    const system = Particles.fromJSON(emitterWith({}), THREE);
+
+    assert.strictEqual(system.emitters[0].damping, 0.006);
+  });
+
   it('should instantiate the eightdiagrams example from JSON', () => {
     const system = Particles.fromJSON(eightdiagrams, THREE);
 

--- a/test/core/fromJSONAsync.spec.js
+++ b/test/core/fromJSONAsync.spec.js
@@ -37,6 +37,24 @@ describe('fromJSONAsync', () => {
     consoleWarnStub.restore();
   });
 
+  it('should read the emitter damping from JSON', async () => {
+    const json = {
+      emitters: [
+        {
+          rate: { particlesMin: 1, particlesMax: 1, perSecondMin: 1, perSecondMax: 1 },
+          rotation: { x: 0, y: 0, z: 0 },
+          position: { x: 0, y: 0, z: 0 },
+          initializers: [],
+          behaviours: [],
+          damping: 0.02,
+        },
+      ],
+    };
+    const system = await Particles.fromJSONAsync(json, THREE);
+
+    assert.strictEqual(system.emitters[0].damping, 0.02);
+  });
+
   it('should call the Texture initializer fromJSON method if the properties contain a texture', async () => {
     const fromJSONSpy = spy(Texture, 'fromJSON');
 


### PR DESCRIPTION
Fixes #269.

The emitter `damping` property (per-frame velocity decay, default `0.006`) was
never read when deserialising a system — unlike every other emitter property —
so a system JSON specifying `damping` had it silently dropped and reverted to the
default on load. It couldn't be authored or round-tripped.

## Change

- `fromJSON` and `fromJSONAsync` now read `damping` (defaulting to
  `DEFAULT_DAMPING` when absent) and apply it to the emitter.

## Tests

- `fromJSON`: reads a custom damping; defaults when absent.
- `fromJSONAsync`: reads a custom damping.
- Full suite green.

## Context

Found while authoring slow, long-lived falling-snow particles downstream: the
default damping decays a small downward velocity to a hover within seconds, and
there was no JSON-level way to disable it. Fast, short-lived particles (rain)
barely notice, which hides the problem.