### PR TITLE
fix(fromJSONAsync): preserve emitter + initializer input order

### DIFF
--- a/src/core/fromJSONAsync.js
+++ b/src/core/fromJSONAsync.js
@@ -36,15 +36,24 @@ const makeInitializers = (items, THREE) =>
     }
 
     const numberOfInitializers = items.length;
-    const madeInitializers = [];
-    const doNotRequireTextureLoading = items.filter(
-      ({ properties }) => !properties.texture
-    );
-    const doRequireTextureLoading = items.filter(
-      ({ properties }) => properties.texture
-    );
+    // Each result is written at its ORIGINAL index, and we resolve once every slot is
+    // filled — so the resolved array preserves the input order regardless of how the
+    // async texture loads below interleave. (Previously initializers were pushed as
+    // they completed: non-texture ones first, then texture ones in load-resolution
+    // order, which reordered them non-deterministically.)
+    const madeInitializers = new Array(numberOfInitializers);
+    let madeCount = 0;
 
-    doNotRequireTextureLoading.forEach(data => {
+    const onMade = (index, initializer) => {
+      madeInitializers[index] = initializer;
+      madeCount += 1;
+
+      if (madeCount === numberOfInitializers) {
+        return resolve(madeInitializers);
+      }
+    };
+
+    items.forEach((data, index) => {
       const { type, properties } = data;
 
       if (!SUPPORTED_JSON_INITIALIZER_TYPES.includes(type)) {
@@ -53,50 +62,28 @@ const makeInitializers = (items, THREE) =>
         );
       }
 
-      if (INITIALIZER_TYPES_THAT_REQUIRE_THREE.includes(type)) {
-        madeInitializers.push(Initializer[type].fromJSON(properties, THREE));
-      } else {
-        madeInitializers.push(Initializer[type].fromJSON(properties));
-      }
+      if (properties.texture) {
+        const textureLoader = new THREE.TextureLoader();
 
-      if (madeInitializers.length === numberOfInitializers) {
-        return resolve(madeInitializers);
-      }
-    });
-
-    doRequireTextureLoading.forEach(data => {
-      const {
-        type,
-        properties,
-        properties: { texture },
-      } = data;
-      const textureLoader = new THREE.TextureLoader();
-
-      if (!SUPPORTED_JSON_INITIALIZER_TYPES.includes(type)) {
-        return reject(
-          `The initializer type ${type} is invalid or not yet supported`
+        textureLoader.load(
+          properties.texture,
+          loadedTexture =>
+            onMade(
+              index,
+              TextureInitializer.fromJSON({ ...properties, loadedTexture }, THREE)
+            ),
+          undefined,
+          reject
         );
+
+        return;
       }
 
-      textureLoader.load(
-        texture,
-        loadedTexture => {
-          madeInitializers.push(
-            TextureInitializer.fromJSON(
-              {
-                ...properties,
-                loadedTexture,
-              },
-              THREE
-            )
-          );
-
-          if (madeInitializers.length === numberOfInitializers) {
-            return resolve(madeInitializers);
-          }
-        },
-        undefined,
-        reject
+      onMade(
+        index,
+        INITIALIZER_TYPES_THAT_REQUIRE_THREE.includes(type)
+          ? Initializer[type].fromJSON(properties, THREE)
+          : Initializer[type].fromJSON(properties)
       );
     });
   });
@@ -139,14 +126,20 @@ const makeEmitters = (emitters, Emitter, THREE, shouldAutoEmit) =>
       return resolve([]);
     }
 
-    const madeEmitters = [];
     const numberOfEmitters = emitters.length;
 
     if (!numberOfEmitters) {
-      return resolve(madeEmitters);
+      return resolve([]);
     }
 
-    emitters.forEach(data => {
+    // Each built emitter is written at its ORIGINAL index, and we resolve once every
+    // slot is filled — so system.emitters preserves the input order regardless of how
+    // the emitters' async initializer/texture loads interleave. (Previously emitters
+    // were pushed as they completed, i.e. in load-resolution order.)
+    const madeEmitters = new Array(numberOfEmitters);
+    let madeCount = 0;
+
+    emitters.forEach((data, index) => {
       const emitter = new Emitter();
       const {
         rate,
@@ -183,13 +176,12 @@ const makeEmitters = (emitters, Emitter, THREE, shouldAutoEmit) =>
           return Promise.resolve(emitter);
         })
         .then(emitter => {
-          madeEmitters.push(
-            shouldAutoEmit
-              ? emitter.emit(totalEmitTimes, life)
-              : emitter.setTotalEmitTimes(totalEmitTimes).setLife(life)
-          );
+          madeEmitters[index] = shouldAutoEmit
+            ? emitter.emit(totalEmitTimes, life)
+            : emitter.setTotalEmitTimes(totalEmitTimes).setLife(life);
+          madeCount += 1;
 
-          if (madeEmitters.length === numberOfEmitters) {
+          if (madeCount === numberOfEmitters) {
             return resolve(madeEmitters);
           }
         })

--- a/test/core/fromJSONAsync.spec.js
+++ b/test/core/fromJSONAsync.spec.js
@@ -187,3 +187,66 @@ describe('fromJSONAsync', () => {
     setLifeSpy.restore();
   });
 });
+
+// Emitters and initializers must come out in the order they were declared, even when
+// their textures load asynchronously and out of that order. The suite above stubs
+// TextureLoader.load to fire synchronously, which hides any resolution-order
+// assembly; here we make loads genuinely async and out of order to exercise it.
+describe('fromJSONAsync — preserves input order under out-of-order async texture loads', () => {
+  let textureLoaderStub, consoleWarnStub;
+
+  // A "slow" texture resolves after a "fast" one — i.e. the reverse of declaration
+  // order — so any code that assembled by resolution order would come out reordered.
+  beforeAll(() => {
+    consoleWarnStub = stub(console, 'warn');
+    textureLoaderStub = stub(TextureLoader.prototype, 'load').callsFake(
+      (texture, onLoad) =>
+        setTimeout(() => onLoad(), texture.includes('slow') ? 20 : 0)
+    );
+  });
+
+  afterAll(() => {
+    textureLoaderStub.restore();
+    consoleWarnStub.restore();
+  });
+
+  const emitter = (positionX, initializers) => ({
+    rate: { particlesMin: 1, particlesMax: 1, perSecondMin: 1, perSecondMax: 1 },
+    rotation: { x: 0, y: 0, z: 0 },
+    position: { x: positionX, y: 0, z: 0 },
+    initializers,
+    behaviours: [],
+  });
+  const textureInit = texture => ({ type: 'BodySprite', properties: { texture } });
+  const massInit = { type: 'Mass', properties: { min: 1, max: 1 } };
+  const radiusInit = { type: 'Radius', properties: { width: 1, height: 1 } };
+
+  it('keeps emitters in declared order even when an earlier one loads its texture later', async () => {
+    const json = {
+      emitters: [
+        emitter(10, [textureInit('slow.png')]), // resolves LAST
+        emitter(20, [textureInit('fast.png')]), // resolves FIRST
+      ],
+    };
+
+    const system = await Particles.fromJSONAsync(json, THREE);
+
+    // Without the fix these come back swapped (fast-loading emitter first).
+    assert.equal(system.emitters[0].position.x, 10);
+    assert.equal(system.emitters[1].position.x, 20);
+  });
+
+  it("keeps an emitter's initializers in declared order (texture first, before sync non-texture ones)", async () => {
+    const json = {
+      emitters: [emitter(0, [textureInit('some.png'), massInit, radiusInit])],
+    };
+
+    const system = await Particles.fromJSONAsync(json, THREE);
+    const { initializers } = system.emitters[0];
+
+    // Without the fix the async texture initializer is pushed last, after the
+    // synchronous Mass/Radius — so index 0 would be Mass, not the Texture.
+    assert.lengthOf(initializers, 3);
+    assert.instanceOf(initializers[0], Texture);
+  });
+});


### PR DESCRIPTION
## Problem

`fromJSONAsync`'s `makeEmitters` and `makeInitializers` assembled their result arrays by **async completion order** — each item was `push`ed in the callback that finished building it. Because texture-bearing initializers load asynchronously (`TextureLoader.load`), this meant:

- **Emitters** came out in whichever order their textures finished loading, not the order declared in the JSON.
- **Initializers within an emitter** came out non-texture-first (pushed synchronously), then texture ones in load-resolution order.

So `system.emitters[i]` did **not** reliably correspond to `json.emitters[i]` once two or more emitters had sprite textures — and the order was timing-dependent (non-deterministic). The **synchronous `fromJSON`** path builds everything in a plain `forEach` and was already order-correct; only the async path drifted.

This bites any consumer that correlates the built system back to its source by position — e.g. an editor mapping an emitter id to its live `Emitter` to patch it in place.

## Fix

Both functions now write each result at its **original index** and resolve once every slot is filled:

```js
const madeEmitters = new Array(numberOfEmitters);
let madeCount = 0;
emitters.forEach((data, index) => {
  // …build…
  .then(emitter => {
    madeEmitters[index] = shouldAutoEmit ? emitter.emit(...) : ...;
    if (++madeCount === numberOfEmitters) resolve(madeEmitters);
  });
});
```

`makeInitializers` additionally collapses its two-phase texture/non-texture split into a single ordered pass over `items`.

## Non-breaking

The async output order was previously **undefined** (it depended on load timing). It now matches the synchronous `fromJSON` path and the input order — what any correct consumer already expects. No API, signature, or semantic change. `makeBehaviours` was already synchronous/ordered and is untouched.

## Tests

Adds two tests that stub `TextureLoader.load` to resolve **out of declared order** (a "slow" texture resolves after a "fast" one). They **fail on the old push-as-resolved code** (`expected 20 to equal 10`; texture initializer not at index 0) and pass now. The pre-existing suite stubbed `load` to fire synchronously, which is exactly why the reorder was never caught.

- `test/core/fromJSONAsync.spec.js` — full suite green (245 tests), lint clean, no circular deps.

## Note for reviewers

Because this changes the async assembly order to be deterministic, if any VR golden-master baselines were captured under the old (timing-dependent) order for multi-emitter/multi-initializer systems, they may need re-baselining — the new order is the correct, stable one.
