### PR TITLE
chore: README housekeeping + dev-log / browser-safety fixes (re-applies #204, #205)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,10 @@
+# Keep the three version shown in README.md in sync with package.json.
+# Only runs when package.json is part of the commit, and only stages README
+# when the sync actually changed it — so ordinary commits are untouched.
+if git diff --cached --name-only | grep -qx 'package.json'; then
+  node scripts/sync-readme-three-version.mjs
+  if ! git diff --quiet -- README.md; then
+    git add README.md
+    echo "pre-commit: synced three version in README.md from package.json"
+  fi
+fi

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Features
 
-- Built and tested against [`three@0.185.1`](https://github.com/mrdoob/three.js); supports `three` `>=0.122.0`
+- Built and tested against [`three@0.185.1`](https://github.com/mrdoob/three.js); supports `three` `>=0.122.0 <1.0.0`
 - The ability to instantiate `three-nebula` particle systems from JSON objects
 - The ability to create particle systems from sprites as well as 3D meshes
 - Many kinds of particle behaviours and initializers

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://github.com/creativelifeform/three-nebula/actions?query=workflow%3Aci"><img src="https://github.com/creativelifeform/three-nebula/workflows/ci/badge.svg"></a>
   <a href="https://coveralls.io/github/creativelifeform/three-nebula?branch=master&kill_cache=1"><img src="https://coveralls.io/repos/github/creativelifeform/three-nebula/badge.svg"></a>
-  <a href="https://threejs.org"><img src="https://img.shields.io/badge/three-%3E%3D0.122.0-%230C7BB8"></a>
+  <a href="https://threejs.org"><img src="https://img.shields.io/badge/three-v0.185.1-%230C7BB8"></a>
 </p>
 
 <hr/>
@@ -25,7 +25,7 @@
 
 ## Features
 
-- Compatible with [`three`](https://github.com/mrdoob/three.js) `>=0.122.0` (tested against the latest release)
+- Built and tested against [`three@0.185.1`](https://github.com/mrdoob/three.js); supports `three` `>=0.122.0`
 - The ability to instantiate `three-nebula` particle systems from JSON objects
 - The ability to create particle systems from sprites as well as 3D meshes
 - Many kinds of particle behaviours and initializers

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://github.com/creativelifeform/three-nebula/actions?query=workflow%3Aci"><img src="https://github.com/creativelifeform/three-nebula/workflows/ci/badge.svg"></a>
   <a href="https://coveralls.io/github/creativelifeform/three-nebula?branch=master&kill_cache=1"><img src="https://coveralls.io/repos/github/creativelifeform/three-nebula/badge.svg"></a>
-  <a href="https://threejs.org"><img src="https://img.shields.io/badge/three-v0.122.0-%230C7BB8"></a>
-  <a href="https://spectrum.chat/nebula"><img src="https://img.shields.io/badge/spectrum-chat-%237816F9"></a>
+  <a href="https://threejs.org"><img src="https://img.shields.io/badge/three-%3E%3D0.122.0-%230C7BB8"></a>
 </p>
 
 <hr/>
@@ -26,7 +25,7 @@
 
 ## Features
 
-- Perfect compatibility with [`three@0.122.0`](https://github.com/mrdoob/three.js)
+- Compatible with [`three`](https://github.com/mrdoob/three.js) `>=0.122.0` (tested against the latest release)
 - The ability to instantiate `three-nebula` particle systems from JSON objects
 - The ability to create particle systems from sprites as well as 3D meshes
 - Many kinds of particle behaviours and initializers
@@ -42,7 +41,7 @@ npm i --save three-nebula
 ### script
 
 ```
-<script type='text/javascript' src='node_modules/three-nebula/build/three-nebula.js'></script>
+<script type='text/javascript' src='node_modules/three-nebula/dist/three-nebula.umd.js'></script>
 ```
 
 ## Usage
@@ -50,7 +49,10 @@ npm i --save three-nebula
 ### Module
 
 ```javascript
+import * as THREE from 'three';
+
 import System, {
+  SpriteRenderer,
   Emitter,
   Rate,
   Span,
@@ -58,18 +60,17 @@ import System, {
   Mass,
   Radius,
   Life,
-  Velocity,
-  PointZone,
+  RadialVelocity,
   Vector3D,
   Alpha,
   Scale,
   Color,
+  PointZone,
 } from 'three-nebula';
-import * as THREE from 'three';
 
 const system = new System();
-const emitter = new Emitter();
 const renderer = new SpriteRenderer(threeScene, THREE);
+const emitter = new Emitter();
 
 // Set emitter rate (particles per second) as well as the particle initializers and behaviours
 emitter
@@ -84,14 +85,26 @@ emitter
   .setBehaviours([
     new Alpha(1, 0),
     new Scale(0.1, 1.3),
-    new Color(new THREE.Color(), new THREE.Color()),
-  ]);
+    new Color(new THREE.Color(0xff0000), new THREE.Color(0x0000ff)),
+  ])
+  .emit();
 
 // add the emitter and a renderer to your particle system
 system
-  .addEmitter(emitter)
   .addRenderer(renderer)
-  .emit({ onStart, onUpdate, onEnd });
+  .addEmitter(emitter)
+  .emit({
+    onStart: () => {},
+    onUpdate: () => {},
+    onEnd: () => {},
+  });
+
+// drive the system from your render loop
+const animate = () => {
+  system.update();
+  requestAnimationFrame(animate);
+};
+requestAnimationFrame(animate);
 ```
 
 You can also instantiate your system from a JSON object
@@ -250,7 +263,7 @@ const json = {
   ],
 };
 
-new System.fromJSONAsync(json, THREE).then(system => {
+System.fromJSONAsync(json, THREE).then(system => {
   console.log(system);
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "domino": "^2.1.1",
         "eslint": "^8.1.0",
         "eslint-plugin-import": "^2.25.2",
+        "husky": "^9.1.7",
         "lodash": "^4.17.21",
         "pixelmatch": "^7.2.0",
         "pngjs": "^7.0.0",
@@ -3343,6 +3344,22 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -7967,6 +7984,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
     "vr:baseline": "node vr/capture-all.mjs --baselines",
     "vr:diff": "node vr/diff.mjs",
     "vr:montage": "node vr/montage.mjs",
-    "ci:src": "npm run lint && npm run coverage",
-    "ci:website": "npm run ci --prefix website"
+    "ci:src": "npm run readme:check-three && npm run lint && npm run coverage",
+    "ci:website": "npm run ci --prefix website",
+    "readme:sync-three": "node scripts/sync-readme-three-version.mjs",
+    "readme:check-three": "node scripts/sync-readme-three-version.mjs --check",
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -63,6 +66,7 @@
     "domino": "^2.1.1",
     "eslint": "^8.1.0",
     "eslint-plugin-import": "^2.25.2",
+    "husky": "^9.1.7",
     "lodash": "^4.17.21",
     "pixelmatch": "^7.2.0",
     "pngjs": "^7.0.0",

--- a/scripts/sync-readme-three-version.mjs
+++ b/scripts/sync-readme-three-version.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+/**
+ * Keep the three.js version shown in README.md in sync with package.json.
+ *
+ * Two spots are kept up to date:
+ *   1. the shields.io badge   -> three-vX.Y.Z
+ *   2. the feature bullet      -> "Built and tested against `three@X.Y.Z`; supports `three` `<range>`"
+ *
+ * Source of truth:
+ *   - devDependencies.three   -> the concrete version we build & test against
+ *   - peerDependencies.three  -> the supported range
+ *
+ * Usage:
+ *   node scripts/sync-readme-three-version.mjs            # rewrite README in place
+ *   node scripts/sync-readme-three-version.mjs --check    # exit 1 if out of date (no write)
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgPath = resolve(root, 'package.json');
+const readmePath = resolve(root, 'README.md');
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const rawDev = pkg.devDependencies?.three;
+const peerRange = pkg.peerDependencies?.three;
+
+if (!rawDev) {
+  console.error(
+    'sync-readme-three-version: no devDependencies.three in package.json'
+  );
+  process.exit(1);
+}
+
+// Strip semver range operators (^ ~ >= <= > < =) to get the concrete version.
+const tested = rawDev.replace(/^[\^~>=<\s]+/, '').trim();
+const supports = (peerRange || `>=${tested}`).trim();
+
+const before = readFileSync(readmePath, 'utf8');
+
+let after = before
+  // 1) badge: .../badge/three-vX.Y.Z-...
+  .replace(/(img\.shields\.io\/badge\/three-v)[^-\s)"]+/, `$1${tested}`)
+  // 2) feature bullet (keeps whatever URL is already linked)
+  .replace(
+    /(- Built and tested against \[`three@)[^`]+(`\]\([^)]+\); supports `three` `)[^`]+(`)/,
+    `$1${tested}$2${supports}$3`
+  );
+
+if (after === before) {
+  console.log(
+    `README three version already in sync (three@${tested}, supports ${supports}).`
+  );
+  process.exit(0);
+}
+
+if (process.argv.includes('--check')) {
+  console.error(
+    `README three version is out of date (expected three@${tested}, supports ${supports}).\n` +
+      'Run: npm run readme:sync-three'
+  );
+  process.exit(1);
+}
+
+writeFileSync(readmePath, after);
+console.log(`Synced README to three@${tested} (supports ${supports}).`);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -22,21 +22,11 @@ export const VERLET = 'verlet';
 export const BIND_EMITTER_EVENT = false;
 
 export const __DEV__ = () => {
-  if (!process) {
+  // `typeof` guards the bare `process` reference — in a browser `process` is
+  // undeclared, so `!process` would throw a ReferenceError rather than be false.
+  if (typeof process === 'undefined' || !process.env) {
     return false;
   }
 
-  if (!process.env) {
-    return false;
-  }
-
-  if (!process.env.NODE_ENV) {
-    return false;
-  }
-
-  if (process.env.NODE_ENV !== 'development') {
-    return false;
-  }
-
-  return true;
+  return process.env.NODE_ENV === 'development';
 };

--- a/src/renderer/BaseRenderer.js
+++ b/src/renderer/BaseRenderer.js
@@ -6,7 +6,6 @@ import {
 } from '../events/constants';
 
 import { RENDERER_TYPE_BASE } from './types';
-import { __DEV__ } from '../constants';
 
 export default class BaseRenderer {
   constructor(type = RENDERER_TYPE_BASE) {
@@ -45,8 +44,6 @@ export default class BaseRenderer {
     ) {
       self.onParticleDead.call(self, particle);
     });
-
-    this.logRendererType();
   }
 
   remove() {
@@ -72,17 +69,4 @@ export default class BaseRenderer {
    * @abstract
    */
   onSystemUpdate(system) {} // eslint-disable-line
-
-  /**
-   * Logs the renderer type being used when in development mode.
-   *
-   * @return void
-   */
-  logRendererType() {
-    if (!__DEV__) {
-      return;
-    }
-
-    console.log(`${this.type}`);
-  }
 }

--- a/src/renderer/GPURenderer/common/TextureAtlas/index.js
+++ b/src/renderer/GPURenderer/common/TextureAtlas/index.js
@@ -57,7 +57,7 @@ export default class TextureAtlas {
    *
    */
   log(...args) {
-    if (!__DEV__) {
+    if (!__DEV__()) {
       return;
     }
 


### PR DESCRIPTION
README housekeeping plus two dev-log bug fixes. Re-applies two long-stale contributor PRs fresh (credit to @wmcmurray).

> The sandbox modernisation that originally lived here has been split into #273.

## Renderer dev-log fixes (re-applies #205)
`__DEV__` (`src/constants/index.js`) is a **function**, so `if (!__DEV__)` was always false — the guarded `console.log` calls ran unconditionally, including in production.
- `BaseRenderer`: removed `logRendererType()` and its call — per #205.
- `TextureAtlas`: same bug, not in the original PR — logged on every texture add / atlas rebuild. Guard now invokes `__DEV__()`.

## `__DEV__` made browser-safe
Invoking `__DEV__()` surfaced a latent crash: it referenced the bare global `process`, throwing a `ReferenceError` in browsers (undeclared identifier) and taking out the GPU renderer on every texture add. Now guarded with `typeof process`. (These two commits are a unit — the `__DEV__()` call and its browser-safety fix must land together.)

## README fixes (re-applies #204 + stale references)
- Module example: import the missing `SpriteRenderer`, call `.emit()`, define callbacks, drive a RAF + `system.update()` loop (previously it never rendered). Based on #204.
- Dropped `new` from `System.fromJSONAsync` (static, not a constructor).
- Script-tag path → `dist/three-nebula.umd.js`.
- `three` badge + feature line state the concrete tested version (`0.185.1`) and the supported range (`>=0.122.0 <1.0.0`); removed the dead Spectrum chat badge (shut down 2021).

## Keep the three version in sync
`scripts/sync-readme-three-version.mjs` rewrites the badge + feature bullet from `package.json` (`devDependencies.three` → tested version, `peerDependencies.three` → range). Wired via a **husky pre-commit** hook (syncs + re-stages only when `package.json` is in the commit and the README changed) and a **`ci:src`** check (`readme:check-three`) so CI fails on drift. Manual: `npm run readme:sync-three`.

## Verification
- `npm run lint` — 0 errors; `npm test` — 245 passing
- sync script idempotent + `--check`; pre-commit hook exercised with a simulated `three` bump

Closes #204
Closes #205