### PR TITLE
fix(build): repoint stale src/index.js entry references to the TS entry

### DIFF
--- a/vr/vite.config.js
+++ b/vr/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
   root: dir,
   resolve: {
     alias: {
-      'three-nebula': path.resolve(repoRoot, 'src/index.js'),
+      'three-nebula': path.resolve(repoRoot, 'src/index.ts'),
     },
   },
   server: {

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -13,6 +13,10 @@ const {
 const nextConfig = {
   // Static export (replaces the removed `next export` / `exportPathMap`).
   output: 'export',
+  // The three-nebula source is now TypeScript and lives outside this app root
+  // (`../src`). externalDir makes Next run its SWC transform on that external
+  // dir so the aliased .ts source transpiles (webpack can't parse raw TS).
+  experimental: { externalDir: true },
   images: { unoptimized: true, disableStaticImages: true },
   sassOptions: { includePaths: [path.join(__dirname, 'style')] },
   env: { API_URL, TEST_EMAIL, UA_ID, SENTRY_DSN },
@@ -23,7 +27,7 @@ const nextConfig = {
     // rather than a published npm build — mirrors the VR harness alias.
     config.resolve.alias['three-nebula'] = path.resolve(
       __dirname,
-      '../src/index.js'
+      '../src/index.ts'
     );
 
     // Import image assets as plain URLs — examples call


### PR DESCRIPTION
## What

The TypeScript migration renamed `src/index.js` → `src/index.ts`, but three build configs still referenced the old `.js` path. This repoints them.

- **`website/next.config.js`** — the webpack alias `three-nebula → ../src/index.js` broke the Next site build entirely once the entry became `.ts` (webpack parses raw JS natively but has no loader for external TS, so it failed with *"Module parse failed"* on `import type`). Repointed to `../src/index.ts` and enabled `experimental.externalDir` so Next's SWC transpiles the external source.
- **`vr/vite.config.js`** — the alias only worked via Vite's silent `.js`→`.ts` extension fallback; repointed explicitly for clarity.

## Why it slipped through the migration

The migration's verification ran through the **Vite**-based sandbox/VR harness, which transpiles TS out of the box, so the stale aliases still resolved there. The **website is built by Next/webpack**, which was never exercised during the migration — so its broken alias only surfaced now.

## Verification

- `npm --prefix website run build` — succeeds (previously failed to compile).
- `npm run vr && npm run vr:diff` — golden master still green with the `.ts` alias.

## Notes

- The equivalent `vite.sandbox.config.js` fix rides along with the `fix/issue-133` branch (its experiment needed it); this PR covers the website + VR configs.