### PR TITLE
docs(readme): badges + three-line cleanup + VR suite docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,23 @@ run(init);
 
 `run` (in `sandbox/common/`) sets up the scene, camera, renderer and animation loop, calls your `init` with `{ scene, camera, renderer }`, and drives `system.update()` every frame — so an experiment only has to describe the system it wants to see.
 
+### Visual regression testing
+
+The golden-master visual regression (VR) suite lives in `./vr`. It renders the library's example scenes — kept in `sandbox/examples/`, decoupled from the docs website — through a deterministic headless harness and diffs each screenshot against a committed baseline.
+
+```
+npm run vr           # render every example, check determinism (render twice, diff)
+npm run vr:diff      # diff the latest render against the committed baselines
+npm run vr:baseline  # (re)write the baselines in vr/baselines/
+npm run vr:montage   # stitch the captures into one overview grid
+```
+
+Determinism comes from the harness, not luck: it seeds the global RNG, pins `requestAnimationFrame`, and captures a fixed number of frames, so a given example renders the same pixels every run. Baselines are compared with `pixelmatch`, and the image files are tracked with Git LFS.
+
+**Why SwiftShader.** The captures run on headless Chromium with WebGL forced onto SwiftShader (Google's software rasteriser) via `--use-gl=angle --use-angle=swiftshader`. That's deliberate: the golden master is diffed near-pixel-exact and committed to the repo, and real GPUs don't produce identical pixels across machines. This is an OSS library — we can't pin the CI runner — so a hardware-rendered baseline would flake everywhere; SwiftShader renders bit-identical on any machine, which is what makes a committable baseline viable.
+
+**The trade-off.** SwiftShader does not render the `GPURenderer`'s point sprites faithfully (they come out blocky regardless of the real output), so VR is trustworthy for the CPU-material renderers (`SpriteRenderer` / `MeshRenderer`) but **blind to `GPURenderer` visual correctness** — validate GPU changes in a real/headed browser plus unit tests. See [`vr/README.md`](vr/README.md) for the full rationale.
+
 ## License
 
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://github.com/creativelifeform/three-nebula/actions?query=workflow%3Aci"><img src="https://github.com/creativelifeform/three-nebula/workflows/ci/badge.svg"></a>
   <a href="https://coveralls.io/github/creativelifeform/three-nebula?branch=master&kill_cache=1"><img src="https://coveralls.io/repos/github/creativelifeform/three-nebula/badge.svg"></a>
   <a href="https://threejs.org"><img src="https://img.shields.io/badge/three-v0.185.1-%230C7BB8"></a>
+  <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white"></a>
 </p>
 
 <hr/>
@@ -25,7 +26,7 @@
 
 ## Features
 
-- Built and tested against [`three@0.185.1`](https://github.com/mrdoob/three.js); supports `three` `>=0.122.0 <1.0.0`
+- Built and tested against [`three@0.185.1`](https://github.com/mrdoob/three.js)
 - The ability to instantiate `three-nebula` particle systems from JSON objects
 - The ability to create particle systems from sprites as well as 3D meshes
 - Many kinds of particle behaviours and initializers

--- a/scripts/sync-readme-three-version.mjs
+++ b/scripts/sync-readme-three-version.mjs
@@ -5,11 +5,10 @@
  *
  * Two spots are kept up to date:
  *   1. the shields.io badge   -> three-vX.Y.Z
- *   2. the feature bullet      -> "Built and tested against `three@X.Y.Z`; supports `three` `<range>`"
+ *   2. the feature bullet      -> "Built and tested against `three@X.Y.Z`"
  *
  * Source of truth:
  *   - devDependencies.three   -> the concrete version we build & test against
- *   - peerDependencies.three  -> the supported range
  *
  * Usage:
  *   node scripts/sync-readme-three-version.mjs            # rewrite README in place
@@ -26,7 +25,6 @@ const readmePath = resolve(root, 'README.md');
 
 const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const rawDev = pkg.devDependencies?.three;
-const peerRange = pkg.peerDependencies?.three;
 
 if (!rawDev) {
   console.error(
@@ -37,7 +35,6 @@ if (!rawDev) {
 
 // Strip semver range operators (^ ~ >= <= > < =) to get the concrete version.
 const tested = rawDev.replace(/^[\^~>=<\s]+/, '').trim();
-const supports = (peerRange || `>=${tested}`).trim();
 
 const before = readFileSync(readmePath, 'utf8');
 
@@ -46,24 +43,22 @@ let after = before
   .replace(/(img\.shields\.io\/badge\/three-v)[^-\s)"]+/, `$1${tested}`)
   // 2) feature bullet (keeps whatever URL is already linked)
   .replace(
-    /(- Built and tested against \[`three@)[^`]+(`\]\([^)]+\); supports `three` `)[^`]+(`)/,
-    `$1${tested}$2${supports}$3`
+    /(- Built and tested against \[`three@)[^`]+(`\]\([^)]+\))/,
+    `$1${tested}$2`
   );
 
 if (after === before) {
-  console.log(
-    `README three version already in sync (three@${tested}, supports ${supports}).`
-  );
+  console.log(`README three version already in sync (three@${tested}).`);
   process.exit(0);
 }
 
 if (process.argv.includes('--check')) {
   console.error(
-    `README three version is out of date (expected three@${tested}, supports ${supports}).\n` +
+    `README three version is out of date (expected three@${tested}).\n` +
       'Run: npm run readme:sync-three'
   );
   process.exit(1);
 }
 
 writeFileSync(readmePath, after);
-console.log(`Synced README to three@${tested} (supports ${supports}).`);
+console.log(`Synced README to three@${tested}.`);


### PR DESCRIPTION
A few README improvements.

## three version line + badge
- **Removed** the odd `; supports `three` `>=0.122.0 <1.0.0`` clause — the bullet now reads simply *Built and tested against `three@0.185.1`*.
- **Added a TypeScript badge** alongside the CI / coverage / three badges.
- **Updated `scripts/sync-readme-three-version.mjs`** so it no longer manages the support range (regex trimmed, `peerDependencies` no longer read). `readme:check-three` stays green and still syncs the tested-against version on future bumps.

## VR testing docs
- **New "Visual regression testing" subsection** under Development: what the suite renders (`sandbox/examples/`), the `vr:*` commands, how determinism works (seeded RNG, pinned rAF, fixed frames, `pixelmatch`, LFS baselines), **why it uses SwiftShader** (bit-identical baselines for an OSS lib that can't pin CI runners), and the **GPURenderer blind spot**. Links to `vr/README.md` for the full rationale.

Verified: `readme:check-three` passes. Please **squash-merge**.