### PR TITLE
feat(sandbox): WebGPU Level 0 — CPU-material renderers work under WebGPURenderer

### DIFF
--- a/sandbox/experiments/webgpu-renderers/index.html
+++ b/sandbox/experiments/webgpu-renderers/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU — CPU-material renderers (Level 0)</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/webgpu-renderers/index.js
+++ b/sandbox/experiments/webgpu-renderers/index.js
@@ -1,0 +1,86 @@
+// Level 0 audit for spec 07: do three-nebula's CPU-material renderers
+// (SpriteRenderer / MeshRenderer) render under three's WebGPURenderer with no
+// library changes? We reuse the existing example scenes verbatim and only swap
+// the host renderer WebGLRenderer -> WebGPURenderer.
+//
+//   ?mode=sprite  (default) — SpriteRenderer (SpriteMaterial, unlit)
+//   ?mode=mesh              — MeshRenderer (MeshLambertMaterial, lit)
+import * as THREE from 'three/webgpu';
+
+const mode =
+  new URLSearchParams(location.search).get('mode') === 'mesh'
+    ? 'mesh'
+    : 'sprite';
+
+// Diagnostics surfaced for the headed probe / console.
+const diag = {
+  mode,
+  hasNavigatorGPU: typeof navigator !== 'undefined' && !!navigator.gpu,
+  initialized: false,
+  rendererType: null,
+  backend: null,
+  particles: 0,
+  frames: 0,
+  error: null,
+};
+window.__webgpu = diag;
+
+async function main() {
+  const canvas = document.getElementById('canvas');
+  const { clientWidth: w, clientHeight: h } = canvas;
+
+  const renderer = new THREE.WebGPURenderer({
+    canvas,
+    alpha: true,
+    antialias: true,
+  });
+
+  await renderer.init(); // WebGPURenderer init is async
+  renderer.setSize(w, h, false);
+  renderer.setClearColor(0x000000, 1);
+
+  diag.initialized = true;
+  diag.rendererType = renderer.constructor.name;
+  diag.backend = renderer.backend?.constructor?.name ?? null;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(70, w / h, 1, 10000);
+
+  // Lit rig for the mesh materials (sprites are unlit — harmless there).
+  const L = Math.PI;
+  scene.add(new THREE.AmbientLight(0xffffff, 0.5 * L));
+  const dir = new THREE.DirectionalLight(0xffffff, 1 * L);
+  dir.position.set(1, 1, 1);
+  scene.add(dir);
+
+  // Reuse the existing example scenes unchanged — only THREE is three/webgpu.
+  const mod =
+    mode === 'mesh'
+      ? await import('/examples/MeshRenderer/init.js')
+      : await import('/examples/SpriteRendererGravity/init.js');
+  const system = await mod.default(THREE, { scene, camera, renderer });
+  diag.system = system;
+
+  async function animate() {
+    try {
+      system.update();
+      diag.particles = system.emitters.reduce(
+        (n, e) => n + e.particles.length,
+        0
+      );
+      await renderer.renderAsync(scene, camera);
+      diag.frames++;
+      requestAnimationFrame(animate);
+    } catch (e) {
+      diag.error = String((e && e.stack) || e);
+      console.error(e);
+    }
+  }
+
+  animate();
+}
+
+main().catch(e => {
+  diag.error = String((e && e.stack) || e);
+  console.error(e);
+});

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,11 @@
     <nav>
       <ul>
         <li>
+          <a href="experiments/webgpu-renderers/index.html">
+            WebGPU — Sprite &amp; Mesh renderers (Level 0) — add ?mode=mesh
+          </a>
+        </li>
+        <li>
           <a href="experiments/additive-blending-scene-background-cpu/index.html">
             Additive Blending — Scene Background (CPU)
           </a>

--- a/specs/07-webgpu-support.md
+++ b/specs/07-webgpu-support.md
@@ -130,6 +130,25 @@ renderers lean on:
 **Packaging: zero new dependencies.** These renderers import no node/TSL code, so Level 0
 ships in the core bundle at the current three floor; only the *host's* three must be r171+.
 
+### Findings (audited 2026-08-05, `three@0.185.1`, real GPU via headed Chromium)
+
+**Level 0 is free — confirmed.** The existing example scenes were run *verbatim*, with only
+the host renderer swapped `WebGLRenderer` → three's `WebGPURenderer` (real `WebGPUBackend`,
+not the WebGL2 fallback). Sandbox experiment: `sandbox/experiments/webgpu-renderers`
+(`?mode=sprite|mesh`).
+
+- **`SpriteRenderer`** (`SpriteMaterial`, additive): renders correctly — textured soft
+  sprites, blending and colours all right. Auto-converted, no changes.
+- **`MeshRenderer`** (`MeshLambertMaterial`, lit): renders correctly — lit spheres/cubes,
+  correct shading and colour. Auto-converted, lights work, no changes.
+- Both ran hundreds of frames with live particles and **zero errors**; `import * as THREE
+  from 'three/webgpu'` supplies the full namespace the renderers need.
+- `WebGPURenderer.init()` is async but the library never touches the renderer object, so the
+  host owning the async init is sufficient — no library change needed there either.
+
+**Conclusion:** the CPU-material renderers need no work for WebGPU. The entire remaining
+effort is **Level 1** (the `GPURenderer` TSL rebuild).
+
 ---
 
 ## Level 1 — a TSL / node `GPURenderer`


### PR DESCRIPTION
First step of WebGPU support (spec 07). **Level 0 is free — confirmed on a real GPU.**

Ran the existing example scenes **verbatim**, swapping only the host renderer `WebGLRenderer` → three's `WebGPURenderer` (real `WebGPUBackend`, headed Chromium on Apple M1 Pro):

| Renderer | Material | Result |
|---|---|---|
| `SpriteRenderer` | `SpriteMaterial` (additive) | ✅ textured soft sprites, blending + colours correct |
| `MeshRenderer` | `MeshLambertMaterial` (lit) | ✅ lit spheres/cubes, correct shading + colour |

Both ran hundreds of frames with live particles and **zero errors** — `import * as THREE from 'three/webgpu'` supplies the full namespace, standard materials auto-convert, and the library never touches the renderer object (so the async `init()` is the host's concern).

## What's here
- **New sandbox experiment** `webgpu-renderers` (`?mode=sprite|mesh`) demonstrating both renderers under `WebGPURenderer`.
- **Level 0 findings recorded** in `specs/07-webgpu-support.md`.

## Conclusion
No library changes needed for the CPU-material renderers. The entire remaining WebGPU effort is **Level 1** — the `GPURenderer` TSL rebuild — which will be its own PR.

Please **squash-merge**.