### PR TITLE
feat: WebGPU support — three-nebula/webgpu GPURenderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/three-nebula.mjs",
       "require": "./dist/three-nebula.cjs"
+    },
+    "./webgpu": {
+      "types": "./dist/types/webgpu/index.d.ts",
+      "import": "./dist/three-nebula-webgpu.mjs",
+      "require": "./dist/three-nebula-webgpu.cjs"
     }
   },
   "directories": {
@@ -19,8 +24,9 @@
     "website": "website"
   },
   "scripts": {
-    "build": "vite build && npm run build:types",
+    "build": "vite build && vite build --config vite.webgpu.config.js && npm run build:types && npm run build:types:webgpu",
     "build:types": "tsc -p tsconfig.types.json",
+    "build:types:webgpu": "node scripts/build-webgpu-types.mjs",
     "dev": "vite build --watch",
     "docs": "serve docs",
     "docs:build": "./scripts/docs-build",
@@ -34,13 +40,14 @@
     "vr:baseline": "node vr/capture-all.mjs --baselines",
     "vr:diff": "node vr/diff.mjs",
     "vr:montage": "node vr/montage.mjs",
-    "ci:src": "npm run readme:check-three && npm run typecheck && npm run lint && npm run coverage",
+    "ci:src": "npm run readme:check-three && npm run typecheck && npm run typecheck:webgpu && npm run lint && npm run coverage",
     "ci:website": "npm run ci --prefix website",
     "readme:sync-three": "node scripts/sync-readme-three-version.mjs",
     "readme:check-three": "node scripts/sync-readme-three-version.mjs --check",
     "prepare": "husky",
     "sandbox": "vite --config vite.sandbox.config.js",
     "typecheck": "tsc --noEmit",
+    "typecheck:webgpu": "tsc -p tsconfig.webgpu.json",
     "format": "prettier --write \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\""
   },

--- a/sandbox/experiments/webgpu-gpurenderer-multi/index.html
+++ b/sandbox/experiments/webgpu-gpurenderer-multi/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU GPURenderer — multi-texture atlas parity</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+  <body>
+    <div id="app"><canvas id="canvas"></canvas></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/webgpu-gpurenderer-multi/index.js
+++ b/sandbox/experiments/webgpu-gpurenderer-multi/index.js
@@ -1,0 +1,51 @@
+// Level 1 multi-texture parity (spec 07): render the GpuRenderer example (5
+// different textures) with the reference SpriteRenderer vs the real WebGPU
+// batched renderer (three-nebula/webgpu) — both under three's WebGPURenderer.
+//
+//   ?renderer=sprite  (default) — reference: one THREE.Sprite per particle
+//   ?renderer=webgpu            — three-nebula/webgpu GPURenderer (atlas, 1 draw)
+import * as THREE from 'three/webgpu';
+import ParticleSystem, { SpriteRenderer } from 'three-nebula';
+import { GPURenderer } from 'three-nebula/webgpu';
+import SYSTEM from '../../examples/GpuRenderer/data.js';
+
+const mode =
+  new URLSearchParams(location.search).get('renderer') === 'webgpu'
+    ? 'webgpu'
+    : 'sprite';
+
+async function main() {
+  const canvas = document.getElementById('canvas');
+  const { clientWidth: w, clientHeight: h } = canvas;
+  const renderer = new THREE.WebGPURenderer({ canvas, alpha: false, antialias: true });
+  await renderer.init();
+  renderer.setSize(w, h, false);
+  renderer.setClearColor(0x000000, 1);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(70, w / h, 1, 10000);
+  camera.position.z = 50;
+
+  const system = await ParticleSystem.fromJSONAsync(
+    SYSTEM.particleSystemState ?? SYSTEM,
+    THREE,
+    { shouldAutoEmit: true }
+  );
+  system.addRenderer(
+    mode === 'webgpu' ? new GPURenderer(scene, THREE) : new SpriteRenderer(scene, THREE)
+  );
+
+  window.__parity = { mode, particles: () => system.emitters.reduce((n, e) => n + e.particles.length, 0) };
+
+  async function animate() {
+    system.update();
+    await renderer.renderAsync(scene, camera);
+    requestAnimationFrame(animate);
+  }
+  animate();
+}
+
+main().catch(e => {
+  window.__parityError = String((e && e.stack) || e);
+  console.error(e);
+});

--- a/sandbox/experiments/webgpu-gpurenderer-spike/index.html
+++ b/sandbox/experiments/webgpu-gpurenderer-spike/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU GPURenderer spike — instanced quads (TSL)</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+  <body>
+    <div id="app"><canvas id="canvas"></canvas></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/webgpu-gpurenderer-spike/index.js
+++ b/sandbox/experiments/webgpu-gpurenderer-spike/index.js
@@ -1,0 +1,74 @@
+// Level 1 spike (spec 07): prove the instanced-quad TSL approach for the batched
+// particle renderer under three's WebGPURenderer — the replacement for the GLSL
+// gl.POINTS GPURenderer. N camera-facing textured quads, per-instance colour,
+// additive. If this renders correctly the full GPURenderer rebuild is de-risked.
+import * as THREE from 'three/webgpu';
+import { texture, uv, attribute } from 'three/tsl';
+
+const N = 600;
+const diag = { rendered: false, backend: null, error: null };
+window.__spike = diag;
+
+async function main() {
+  const canvas = document.getElementById('canvas');
+  const { clientWidth: w, clientHeight: h } = canvas;
+
+  const renderer = new THREE.WebGPURenderer({ canvas, antialias: true });
+  await renderer.init();
+  renderer.setSize(w, h, false);
+  renderer.setClearColor(0x000000, 1);
+  diag.backend = renderer.backend?.constructor?.name ?? null;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(60, w / h, 0.1, 1000);
+  camera.position.z = 60;
+
+  const tex = await new THREE.TextureLoader().loadAsync('/assets/dot.png');
+
+  // Per-instance data in instanced attributes; SpriteNodeMaterial billboards
+  // each quad at positionNode (= the instance offset) with scaleNode / colour.
+  const off = new Float32Array(N * 3);
+  const col = new Float32Array(N * 3);
+  const scl = new Float32Array(N);
+  const color = new THREE.Color();
+  for (let i = 0; i < N; i++) {
+    off[i * 3 + 0] = (Math.random() - 0.5) * 70;
+    off[i * 3 + 1] = (Math.random() - 0.5) * 45;
+    off[i * 3 + 2] = (Math.random() - 0.5) * 25;
+    color.setHSL(Math.random(), 0.9, 0.6);
+    col[i * 3 + 0] = color.r;
+    col[i * 3 + 1] = color.g;
+    col[i * 3 + 2] = color.b;
+    scl[i] = 2 + Math.random() * 5;
+  }
+
+  const base = new THREE.PlaneGeometry(1, 1);
+  const geo = new THREE.InstancedBufferGeometry();
+  geo.index = base.index;
+  geo.setAttribute('position', base.attributes.position);
+  geo.setAttribute('uv', base.attributes.uv);
+  geo.instanceCount = N;
+  geo.setAttribute('aOffset', new THREE.InstancedBufferAttribute(off, 3));
+  geo.setAttribute('aColor', new THREE.InstancedBufferAttribute(col, 3));
+  geo.setAttribute('aScale', new THREE.InstancedBufferAttribute(scl, 1));
+
+  const mat = new THREE.SpriteNodeMaterial({
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+  mat.positionNode = attribute('aOffset'); // billboard centre per instance
+  mat.scaleNode = attribute('aScale');
+  mat.colorNode = texture(tex, uv()).mul(attribute('aColor'));
+
+  const mesh = new THREE.Mesh(geo, mat);
+  scene.add(mesh);
+
+  await renderer.renderAsync(scene, camera);
+  diag.rendered = true;
+}
+
+main().catch(e => {
+  diag.error = String((e && e.stack) || e);
+  console.error(e);
+});

--- a/sandbox/experiments/webgpu-gpurenderer/index.html
+++ b/sandbox/experiments/webgpu-gpurenderer/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU GPURenderer — parity vs SpriteRenderer</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+  <body>
+    <div id="app"><canvas id="canvas"></canvas></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/webgpu-gpurenderer/index.js
+++ b/sandbox/experiments/webgpu-gpurenderer/index.js
@@ -1,0 +1,220 @@
+// Level 1 parity harness (spec 07): render the SAME particle system with the
+// reference SpriteRenderer vs a prototype WebGPU batched renderer, both under
+// three's WebGPURenderer, so we can cross-check the new renderer against a known
+// -good golden reference.
+//
+//   ?renderer=sprite  (default) — reference: one THREE.Sprite per particle
+//   ?renderer=webgpu            — prototype: instanced quads via SpriteNodeMaterial
+import * as THREE from 'three/webgpu';
+import { attribute, texture, uv } from 'three/tsl';
+import ParticleSystem, {
+  Body,
+  Color,
+  Emitter,
+  Gravity,
+  Life,
+  Mass,
+  Position,
+  RadialVelocity,
+  RandomDrift,
+  Rate,
+  Scale,
+  Span,
+  SphereZone,
+  SpriteRenderer,
+  Vector3D,
+  ease,
+} from 'three-nebula';
+import dot from '../../assets/dot.png';
+
+const mode =
+  new URLSearchParams(location.search).get('renderer') === 'webgpu'
+    ? 'webgpu'
+    : 'sprite';
+
+// --- prototype WebGPU batched renderer -------------------------------------
+// Reimplements the GLSL GPURenderer's lifecycle (particle -> instance slot ->
+// per-instance attributes) with instanced quads + a node material. Single
+// texture for now (atlas/rotation/multi-texture come next).
+class WebGPUGPURenderer {
+  constructor(scene, three, { maxParticles = 5000 } = {}) {
+    this.scene = scene;
+    this.THREE = three;
+    this.max = maxParticles;
+    this.freeSlots = [];
+    for (let i = maxParticles - 1; i >= 0; i--) this.freeSlots.push(i);
+    this.idToIndex = new Map();
+    this.highWater = 0;
+    this.dirty = false;
+    this.textureBound = false;
+
+    this.aOffset = new three.InstancedBufferAttribute(new Float32Array(maxParticles * 3), 3);
+    this.aColor = new three.InstancedBufferAttribute(new Float32Array(maxParticles * 3), 3);
+    this.aAlpha = new three.InstancedBufferAttribute(new Float32Array(maxParticles), 1);
+    this.aScale = new three.InstancedBufferAttribute(new Float32Array(maxParticles), 1);
+    this.aRotation = new three.InstancedBufferAttribute(new Float32Array(maxParticles), 1);
+
+    const base = new three.PlaneGeometry(1, 1);
+    const geo = new three.InstancedBufferGeometry();
+    geo.index = base.index;
+    geo.setAttribute('position', base.attributes.position);
+    geo.setAttribute('uv', base.attributes.uv);
+    geo.setAttribute('aOffset', this.aOffset);
+    geo.setAttribute('aColor', this.aColor);
+    geo.setAttribute('aAlpha', this.aAlpha);
+    geo.setAttribute('aScale', this.aScale);
+    geo.setAttribute('aRotation', this.aRotation);
+    geo.instanceCount = 0;
+    this.geometry = geo;
+
+    const mat = new three.SpriteNodeMaterial({
+      transparent: true,
+      depthWrite: false,
+      blending: three.AdditiveBlending,
+    });
+    mat.positionNode = attribute('aOffset');
+    mat.scaleNode = attribute('aScale');
+    mat.rotationNode = attribute('aRotation');
+    mat.opacityNode = attribute('aAlpha');
+    this.material = mat;
+
+    this.mesh = new three.Mesh(geo, mat);
+    this.mesh.frustumCulled = false;
+    scene.add(this.mesh);
+  }
+
+  init(system) {
+    const self = this;
+    const on = (evt, fn) => system.eventDispatcher.addEventListener(evt, fn);
+    on('SYSTEM_UPDATE', () => self.onSystemUpdate());
+    on('PARTICLE_CREATED', p => self.onParticleCreated(p));
+    on('PARTICLE_UPDATE', p => self.onParticleUpdate(p));
+    on('PARTICLE_DEAD', p => self.onParticleDead(p));
+  }
+
+  slot(p) {
+    let i = this.idToIndex.get(p.id);
+    if (i === undefined) {
+      i = this.freeSlots.pop();
+      this.idToIndex.set(p.id, i);
+      this.highWater = Math.max(this.highWater, i + 1);
+      this.geometry.instanceCount = this.highWater;
+    }
+    return i;
+  }
+
+  bindTexture(p) {
+    if (this.textureBound || !(p.body instanceof this.THREE.Sprite)) return;
+    const map = p.body.material.map;
+    if (!map) return;
+    this.material.colorNode = texture(map, uv()).mul(attribute('aColor'));
+    this.material.needsUpdate = true;
+    this.textureBound = true;
+  }
+
+  write(p) {
+    const i = this.slot(p);
+    this.aOffset.array[i * 3 + 0] = p.position.x;
+    this.aOffset.array[i * 3 + 1] = p.position.y;
+    this.aOffset.array[i * 3 + 2] = p.position.z;
+    this.aColor.array[i * 3 + 0] = p.color.r;
+    this.aColor.array[i * 3 + 1] = p.color.g;
+    this.aColor.array[i * 3 + 2] = p.color.b;
+    this.aAlpha.array[i] = p.alpha;
+    this.aScale.array[i] = p.scale * p.radius;
+    this.aRotation.array[i] = p.rotation.z;
+    this.dirty = true;
+  }
+
+  onParticleCreated(p) {
+    this.bindTexture(p);
+    this.write(p);
+  }
+
+  onParticleUpdate(p) {
+    this.write(p);
+  }
+
+  onParticleDead(p) {
+    const i = this.idToIndex.get(p.id);
+    if (i === undefined) return;
+    this.aScale.array[i] = 0;
+    this.idToIndex.delete(p.id);
+    this.freeSlots.push(i);
+    this.dirty = true;
+  }
+
+  onSystemUpdate() {
+    if (!this.dirty) return;
+    for (const a of [this.aOffset, this.aColor, this.aAlpha, this.aScale, this.aRotation])
+      a.needsUpdate = true;
+    this.dirty = false;
+  }
+}
+
+// --- the golden particle system (same as SpriteRendererGravity) ------------
+const createSprite = () => {
+  const map = new THREE.TextureLoader().load(dot);
+  return new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map,
+      color: 0xff0000,
+      blending: THREE.AdditiveBlending,
+      fog: true,
+    })
+  );
+};
+
+const createEmitter = () =>
+  new Emitter()
+    .setRate(new Rate(new Span(10, 15), new Span(0.05, 0.1)))
+    .addInitializers([
+      new Body(createSprite()),
+      new Mass(1),
+      new Life(1, 3),
+      new Position(new SphereZone(20)),
+      new RadialVelocity(new Span(500, 800), new Vector3D(0, 1, 0), 30),
+    ])
+    .addBehaviours([
+      new RandomDrift(10, 10, 10, 0.05),
+      new Scale(new Span(2, 3.5), 0),
+      new Gravity(6),
+      new Color('#FF0026', ['#ffff00', '#ffff11'], Infinity, ease.easeOutSine),
+    ])
+    .setPosition({ x: 0, y: -150 })
+    .emit();
+
+async function main() {
+  const canvas = document.getElementById('canvas');
+  const { clientWidth: w, clientHeight: h } = canvas;
+  const renderer = new THREE.WebGPURenderer({ canvas, alpha: false, antialias: true });
+  await renderer.init();
+  renderer.setSize(w, h, false);
+  renderer.setClearColor(0x000000, 1);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(70, w / h, 1, 10000);
+  camera.position.z = 500;
+
+  const system = new ParticleSystem();
+  system.addEmitter(createEmitter());
+  system.addRenderer(
+    mode === 'webgpu'
+      ? new WebGPUGPURenderer(scene, THREE)
+      : new SpriteRenderer(scene, THREE)
+  );
+
+  window.__parity = { mode, particles: () => system.emitters.reduce((n, e) => n + e.particles.length, 0) };
+
+  async function animate() {
+    system.update();
+    await renderer.renderAsync(scene, camera);
+    requestAnimationFrame(animate);
+  }
+  animate();
+}
+
+main().catch(e => {
+  window.__parityError = String((e && e.stack) || e);
+  console.error(e);
+});

--- a/sandbox/experiments/webgpu-renderers/index.html
+++ b/sandbox/experiments/webgpu-renderers/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebGPU — CPU-material renderers (Level 0)</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/webgpu-renderers/index.js
+++ b/sandbox/experiments/webgpu-renderers/index.js
@@ -1,0 +1,86 @@
+// Level 0 audit for spec 07: do three-nebula's CPU-material renderers
+// (SpriteRenderer / MeshRenderer) render under three's WebGPURenderer with no
+// library changes? We reuse the existing example scenes verbatim and only swap
+// the host renderer WebGLRenderer -> WebGPURenderer.
+//
+//   ?mode=sprite  (default) — SpriteRenderer (SpriteMaterial, unlit)
+//   ?mode=mesh              — MeshRenderer (MeshLambertMaterial, lit)
+import * as THREE from 'three/webgpu';
+
+const mode =
+  new URLSearchParams(location.search).get('mode') === 'mesh'
+    ? 'mesh'
+    : 'sprite';
+
+// Diagnostics surfaced for the headed probe / console.
+const diag = {
+  mode,
+  hasNavigatorGPU: typeof navigator !== 'undefined' && !!navigator.gpu,
+  initialized: false,
+  rendererType: null,
+  backend: null,
+  particles: 0,
+  frames: 0,
+  error: null,
+};
+window.__webgpu = diag;
+
+async function main() {
+  const canvas = document.getElementById('canvas');
+  const { clientWidth: w, clientHeight: h } = canvas;
+
+  const renderer = new THREE.WebGPURenderer({
+    canvas,
+    alpha: true,
+    antialias: true,
+  });
+
+  await renderer.init(); // WebGPURenderer init is async
+  renderer.setSize(w, h, false);
+  renderer.setClearColor(0x000000, 1);
+
+  diag.initialized = true;
+  diag.rendererType = renderer.constructor.name;
+  diag.backend = renderer.backend?.constructor?.name ?? null;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(70, w / h, 1, 10000);
+
+  // Lit rig for the mesh materials (sprites are unlit — harmless there).
+  const L = Math.PI;
+  scene.add(new THREE.AmbientLight(0xffffff, 0.5 * L));
+  const dir = new THREE.DirectionalLight(0xffffff, 1 * L);
+  dir.position.set(1, 1, 1);
+  scene.add(dir);
+
+  // Reuse the existing example scenes unchanged — only THREE is three/webgpu.
+  const mod =
+    mode === 'mesh'
+      ? await import('/examples/MeshRenderer/init.js')
+      : await import('/examples/SpriteRendererGravity/init.js');
+  const system = await mod.default(THREE, { scene, camera, renderer });
+  diag.system = system;
+
+  async function animate() {
+    try {
+      system.update();
+      diag.particles = system.emitters.reduce(
+        (n, e) => n + e.particles.length,
+        0
+      );
+      await renderer.renderAsync(scene, camera);
+      diag.frames++;
+      requestAnimationFrame(animate);
+    } catch (e) {
+      diag.error = String((e && e.stack) || e);
+      console.error(e);
+    }
+  }
+
+  animate();
+}
+
+main().catch(e => {
+  diag.error = String((e && e.stack) || e);
+  console.error(e);
+});

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,21 @@
     <nav>
       <ul>
         <li>
+          <a href="experiments/webgpu-gpurenderer-multi/index.html">
+            WebGPU — GPURenderer multi-texture atlas parity (Level 1) — add ?renderer=webgpu
+          </a>
+        </li>
+        <li>
+          <a href="experiments/webgpu-gpurenderer/index.html">
+            WebGPU — GPURenderer parity vs SpriteRenderer (Level 1) — add ?renderer=webgpu
+          </a>
+        </li>
+        <li>
+          <a href="experiments/webgpu-gpurenderer-spike/index.html">
+            WebGPU — GPURenderer spike (instanced quads, TSL) (Level 1)
+          </a>
+        </li>
+        <li>
           <a href="experiments/webgpu-renderers/index.html">
             WebGPU — Sprite &amp; Mesh renderers (Level 0) — add ?mode=mesh
           </a>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,11 @@
     <nav>
       <ul>
         <li>
+          <a href="experiments/webgpu-renderers/index.html">
+            WebGPU — Sprite &amp; Mesh renderers (Level 0) — add ?mode=mesh
+          </a>
+        </li>
+        <li>
           <a href="experiments/additive-blending-scene-background-cpu/index.html">
             Additive Blending — Scene Background (CPU)
           </a>

--- a/scripts/build-webgpu-types.mjs
+++ b/scripts/build-webgpu-types.mjs
@@ -6,7 +6,9 @@
 // hand-maintain the small public surface in `src/webgpu/public.d.ts` and copy
 // it verbatim to where package.json's `./webgpu` export points its `types`.
 // Its relative imports are depth-consistent between the two locations, so no
-// rewriting is required. `tsconfig.webgpu.json` guards it against drift.
+// rewriting is required. `tsconfig.webgpu.json` checks the declaration is valid
+// and models real usage (it can't diff against the TSL-heavy real class, which
+// hangs tsc); the runtime spec exercises the public members.
 
 import { copyFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';

--- a/scripts/build-webgpu-types.mjs
+++ b/scripts/build-webgpu-types.mjs
@@ -1,0 +1,23 @@
+// Publishes the `three-nebula/webgpu` type declaration.
+//
+// The real `src/webgpu/GPURenderer/index.ts` can't go through `tsc` declaration
+// emit: its TSL node graph produces types too complex for the compiler to
+// serialize (it hangs, then gets killed before emitting anything). Instead we
+// hand-maintain the small public surface in `src/webgpu/public.d.ts` and copy
+// it verbatim to where package.json's `./webgpu` export points its `types`.
+// Its relative imports are depth-consistent between the two locations, so no
+// rewriting is required. `tsconfig.webgpu.json` guards it against drift.
+
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const src = resolve(root, 'src/webgpu/public.d.ts');
+const outDir = resolve(root, 'dist/types/webgpu');
+const out = resolve(outDir, 'index.d.ts');
+
+mkdirSync(outDir, { recursive: true });
+copyFileSync(src, out);
+
+console.log(`webgpu types: ${src} -> ${out}`);

--- a/specs/07-webgpu-support.md
+++ b/specs/07-webgpu-support.md
@@ -130,6 +130,25 @@ renderers lean on:
 **Packaging: zero new dependencies.** These renderers import no node/TSL code, so Level 0
 ships in the core bundle at the current three floor; only the *host's* three must be r171+.
 
+### Findings (audited 2026-08-05, `three@0.185.1`, real GPU via headed Chromium)
+
+**Level 0 is free — confirmed.** The existing example scenes were run *verbatim*, with only
+the host renderer swapped `WebGLRenderer` → three's `WebGPURenderer` (real `WebGPUBackend`,
+not the WebGL2 fallback). Sandbox experiment: `sandbox/experiments/webgpu-renderers`
+(`?mode=sprite|mesh`).
+
+- **`SpriteRenderer`** (`SpriteMaterial`, additive): renders correctly — textured soft
+  sprites, blending and colours all right. Auto-converted, no changes.
+- **`MeshRenderer`** (`MeshLambertMaterial`, lit): renders correctly — lit spheres/cubes,
+  correct shading and colour. Auto-converted, lights work, no changes.
+- Both ran hundreds of frames with live particles and **zero errors**; `import * as THREE
+  from 'three/webgpu'` supplies the full namespace the renderers need.
+- `WebGPURenderer.init()` is async but the library never touches the renderer object, so the
+  host owning the async init is sufficient — no library change needed there either.
+
+**Conclusion:** the CPU-material renderers need no work for WebGPU. The entire remaining
+effort is **Level 1** (the `GPURenderer` TSL rebuild).
+
 ---
 
 ## Level 1 — a TSL / node `GPURenderer`

--- a/specs/07-webgpu-support.md
+++ b/specs/07-webgpu-support.md
@@ -231,13 +231,34 @@ master. Strategy:
 - **Keep** the WebGL VR golden master as the deterministic guard (it already covers the
   CPU-material renderers and the GLSL `GPURenderer`, and simulation stays on CPU so it's
   unaffected).
-- **Unit-test the node graph** — assert the node material/uniforms are constructed and wired
-  (environment-independent, like `test/renderer/TextureAtlas.spec.js`).
+- **Snapshot the node graph + generated shaders** — assert the node material/uniforms are
+  constructed and wired, and snapshot the TSL-generated **WGSL + GLSL** source. Both are
+  environment-independent (no GPU), so this is the **committed deterministic guard** — it
+  catches logic/codegen regressions the way `test/renderer/TextureAtlas.spec.js` guards the
+  atlas.
 - **Real-GPU headed validation** for visual correctness — eyeballed / loose tolerance
   (headed Playwright on a real GPU, as used to validate #293), **not** a committed pixel
   baseline.
-- Optionally a **headed + xvfb GPU smoke job** (does it render non-blank?) rather than
-  pixel-exact.
+
+### Findings (audited 2026-08-05) — the deterministic-headless workarounds don't work
+
+Two plausible ways to get a *deterministic, committable* WebGPU golden master were spiked
+empirically. **Both failed — do not re-attempt:**
+
+- **WebGPURenderer's WebGL2 backend on SwiftShader** (`{ forceWebGL: true }` +
+  `--use-angle=swiftshader`): bit-identical across runs (0px) but **not faithful** — the
+  auto-converted `SpriteMaterial` rendered solid **black**. SwiftShader cannot run three's
+  node-material pipeline faithfully (the same class of problem as its blocky `gl.POINTS`).
+  Deterministic-but-wrong is useless for a baseline.
+- **Software WebGPU adapter, headless** (`--enable-unsafe-webgpu`
+  `--use-webgpu-adapter=swiftshader`): the adapter is obtainable, but the render came back
+  **blank** in headless Playwright — no usable capture.
+
+So the guard is **snapshots (deterministic, committed) + real-GPU headed validation
+(fidelity, manual)** — there is no CI-usable deterministic *pixel* path for WebGPU.
+**Corollary:** the SwiftShader golden master is bound to the classic WebGLRenderer + GLSL
+material path and cannot cover node/WebGPU rendering — relevant when the node `GPURenderer`
+eventually graduates (see _Naming_).
 
 ---
 

--- a/specs/07-webgpu-support.md
+++ b/specs/07-webgpu-support.md
@@ -162,6 +162,11 @@ coexist during the transition**: the GLSL `GPURenderer` (`three-nebula`) for `We
 hosts, the node `GPURenderer` (`three-nebula/webgpu`) for `WebGPURenderer` hosts — until the
 node one graduates (see _Naming_).
 
+**Status: implemented** — shipped as `GPURenderer` from `three-nebula/webgpu` (`src/webgpu`).
+Instanced-quad `SpriteNodeMaterial` + TSL, texture atlas, world-scale sizing; single- and
+multi-texture parity confirmed against `SpriteRenderer` on a real GPU. Guarded by a node-graph
+snapshot test (`test/webgpu/GPURenderer.spec.js`).
+
 Porting notes:
 
 - **Point sprites → instanced quads.** WebGPU has no direct `gl.POINTS` point-sprite
@@ -173,6 +178,12 @@ Porting notes:
   `texture()` / storage samples. **Preserve the #293 mipmap fix** (recreate the atlas
   texture at final size so mipmaps generate) — it is equally necessary here.
 - **Attributes.** Interleaved per-particle buffers → instanced buffer attribute nodes.
+- **Sizing — world-scale (decided).** The GLSL renderer sizes points via
+  `gl_PointSize = size * 600 / distance` — a screen-pixel point-size model with a magic
+  constant. The node renderer instead uses **world-unit scale** (`scale * radius` in world
+  units, matching `SpriteRenderer` and letting perspective handle distance falloff), the more
+  principled model. It is therefore not pixel-identical in *size* to the v1 GPURenderer, but
+  it matches `SpriteRenderer`, which is the intended look. (Confirmed by side-by-side parity.)
 - **Desktop vs Mobile.** Both variants exist today (the Mobile one drops the `DataTexture`
   index for a `canvas.width + 1` normalisation). The node rewrite likely **collapses the
   Desktop/Mobile split** — the backend abstraction removes the reason it existed.

--- a/src/webgpu/GPURenderer/TextureAtlas.ts
+++ b/src/webgpu/GPURenderer/TextureAtlas.ts
@@ -1,0 +1,155 @@
+import type { CanvasTexture, DataTexture, Texture } from 'three';
+import potpack from 'potpack';
+import type { PotpackBox } from 'potpack';
+
+import { ATLAS_INDEX_SIZE } from './constants';
+
+type ThreeWebGPU = typeof import('three/webgpu');
+
+// potpack types x/y as optional (it fills them in when packing), but our
+// entries always carry them — seeded to 0 in `register`, then set by potpack —
+// so we narrow them to required and index the packed rects without guards.
+interface AtlasEntry extends PotpackBox {
+  texture: Texture;
+  x: number;
+  y: number;
+}
+
+/**
+ * Packs many particle textures into a single atlas so the WebGPU renderer can
+ * draw them in one instanced call. Unlike the GLSL renderer's `TextureAtlas`
+ * (which writes to `ShaderMaterial` uniforms), this exposes `atlasTexture` and
+ * `atlasIndex` for the node material to sample directly.
+ *
+ * A particle's texture id (assigned by {@link register}) indexes `atlasIndex`,
+ * a 1-row float texture of tile rects (minU, minV, maxU, maxV).
+ */
+export default class TextureAtlas {
+  three: ThreeWebGPU;
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  atlasTexture: CanvasTexture;
+  atlasIndex: DataTexture;
+  indexData: Float32Array;
+  entries: AtlasEntry[];
+  textureToId: Map<Texture, number>;
+  needsRebuild: boolean;
+
+  constructor(three: ThreeWebGPU) {
+    this.three = three;
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = this.canvas.height = ATLAS_INDEX_SIZE;
+    this.ctx = this.canvas.getContext('2d') as CanvasRenderingContext2D;
+    this.atlasTexture = this.makeAtlasTexture();
+    this.indexData = new Float32Array(ATLAS_INDEX_SIZE * 4);
+    this.atlasIndex = new three.DataTexture(
+      this.indexData,
+      ATLAS_INDEX_SIZE,
+      1,
+      three.RGBAFormat,
+      three.FloatType
+    );
+    this.atlasIndex.magFilter = this.atlasIndex.minFilter = three.NearestFilter;
+    this.atlasIndex.needsUpdate = true;
+    this.entries = [];
+    this.textureToId = new Map();
+    this.needsRebuild = false;
+  }
+
+  /**
+   * A fresh CanvasTexture over the atlas canvas. Recreated on every rebuild so
+   * its mipmaps regenerate cleanly after the canvas is resized/redrawn — the
+   * fix from the GLSL renderer (#293), which the node path needs too.
+   */
+  makeAtlasTexture(): CanvasTexture {
+    const texture = new this.three.CanvasTexture(this.canvas);
+    texture.flipY = false;
+    texture.colorSpace = this.three.SRGBColorSpace;
+    return texture; // mipmaps on (default) => smooth minification of large tiles
+  }
+
+  /**
+   * Registers a texture and returns its stable id. Idempotent per texture.
+   */
+  register(texture: Texture): number {
+    const existing = this.textureToId.get(texture);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const id = this.entries.length;
+
+    this.textureToId.set(texture, id);
+    this.entries.push({ texture, w: 0, h: 0, x: 0, y: 0 });
+    this.needsRebuild = true;
+
+    return id;
+  }
+
+  /**
+   * Rebuilds the atlas if a new texture was registered and all images are
+   * loaded. Returns true if `atlasTexture` was recreated (the caller must
+   * rewire the node graph to the new texture).
+   */
+  update(): boolean {
+    if (!this.needsRebuild) {
+      return false;
+    }
+
+    for (const entry of this.entries) {
+      const image = entry.texture.image as { width?: number } | undefined;
+
+      if (!image || !image.width) {
+        return false; // wait until every image has loaded
+      }
+    }
+
+    for (const entry of this.entries) {
+      const image = entry.texture.image as { width: number; height: number };
+
+      entry.w = image.width;
+      entry.h = image.height;
+    }
+
+    const stats = potpack(this.entries);
+
+    if (this.canvas.width !== stats.w || this.canvas.height !== stats.h) {
+      this.canvas.width = stats.w;
+      this.canvas.height = stats.h;
+    }
+
+    this.ctx.clearRect(0, 0, stats.w, stats.h);
+
+    for (const entry of this.entries) {
+      this.ctx.drawImage(
+        entry.texture.image as CanvasImageSource,
+        entry.x,
+        entry.y,
+        entry.w,
+        entry.h
+      );
+
+      const i = (this.textureToId.get(entry.texture) as number) * 4;
+
+      this.indexData[i + 0] = entry.x / stats.w;
+      this.indexData[i + 1] = entry.y / stats.h;
+      this.indexData[i + 2] = (entry.x + entry.w) / stats.w;
+      this.indexData[i + 3] = (entry.y + entry.h) / stats.h;
+    }
+
+    this.atlasIndex.needsUpdate = true;
+    this.atlasTexture.dispose();
+    this.atlasTexture = this.makeAtlasTexture();
+    this.needsRebuild = false;
+
+    return true;
+  }
+
+  destroy(): void {
+    this.atlasTexture.dispose();
+    this.atlasIndex.dispose();
+    this.entries = [];
+    this.textureToId.clear();
+  }
+}

--- a/src/webgpu/GPURenderer/constants.ts
+++ b/src/webgpu/GPURenderer/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_MAX_PARTICLES = 10000;
+
+// Width of the 1-row float DataTexture that stores per-texture tile rects
+// (r=minU, g=minV, b=maxU, a=maxV), indexed by a particle's texture id.
+export const ATLAS_INDEX_SIZE = 256;

--- a/src/webgpu/GPURenderer/index.ts
+++ b/src/webgpu/GPURenderer/index.ts
@@ -38,10 +38,17 @@ export default class GPURenderer extends BaseRenderer {
   container: Object3D;
   maxParticles: number;
 
+  // Public escape hatches for advanced hosts. NOTE: the published types are
+  // re-declared by hand in ../public.d.ts (tsc can't emit them — the TSL node
+  // types are too complex to serialize). Keep the two in sync when the public
+  // surface below changes.
   mesh: Mesh;
   material: SpriteNodeMaterial;
   geometry: InstancedBufferGeometry;
-  atlas: TextureAtlas;
+
+  // Internal texture-packing plumbing — deliberately not part of the published
+  // surface (exposing it would drag TextureAtlas into the public API).
+  private atlas: TextureAtlas;
 
   private aOffset: InstancedBufferAttribute;
   private aColor: InstancedBufferAttribute;

--- a/src/webgpu/GPURenderer/index.ts
+++ b/src/webgpu/GPURenderer/index.ts
@@ -1,0 +1,235 @@
+import BaseRenderer from '../../renderer/BaseRenderer';
+import type Particle from '../../core/Particle';
+import type {
+  InstancedBufferAttribute,
+  InstancedBufferGeometry,
+  Object3D,
+  Sprite,
+  SpriteMaterial,
+} from 'three';
+import type { Mesh, SpriteNodeMaterial } from 'three/webgpu';
+import { attribute, mix, texture, uv, vec2 } from 'three/tsl';
+
+import TextureAtlas from './TextureAtlas';
+import { ATLAS_INDEX_SIZE, DEFAULT_MAX_PARTICLES } from './constants';
+
+type ThreeWebGPU = typeof import('three/webgpu');
+
+interface RendererOptions {
+  maxParticles?: number;
+}
+
+/**
+ * WebGPU batched particle renderer.
+ *
+ * The node/TSL counterpart of the GLSL `GPURenderer`: draws every particle as a
+ * camera-facing instanced quad (`SpriteNodeMaterial`) in a single call, with
+ * per-instance position / colour / alpha / scale / rotation / texture supplied
+ * through instanced attributes, and multiple textures packed into one atlas.
+ *
+ * Sizing is **world-scale** (`scale * radius` in world units, matching
+ * `SpriteRenderer`), not the GLSL renderer's `gl_PointSize` point-size model.
+ *
+ * Requires the host to use three's `WebGPURenderer`; pass the `three/webgpu`
+ * namespace as `three`.
+ */
+export default class GPURenderer extends BaseRenderer {
+  three: ThreeWebGPU;
+  container: Object3D;
+  maxParticles: number;
+
+  mesh: Mesh;
+  material: SpriteNodeMaterial;
+  geometry: InstancedBufferGeometry;
+  atlas: TextureAtlas;
+
+  private aOffset: InstancedBufferAttribute;
+  private aColor: InstancedBufferAttribute;
+  private aAlpha: InstancedBufferAttribute;
+  private aScale: InstancedBufferAttribute;
+  private aRotation: InstancedBufferAttribute;
+  private aTexID: InstancedBufferAttribute;
+
+  private idToIndex: Map<string, number>;
+  private freeSlots: number[];
+  private highWater: number;
+  private dirty: boolean;
+
+  constructor(
+    container: Object3D,
+    three: ThreeWebGPU,
+    options: RendererOptions = {}
+  ) {
+    super('WebGPUGPURenderer');
+
+    const max = options.maxParticles ?? DEFAULT_MAX_PARTICLES;
+
+    this.three = three;
+    this.container = container;
+    this.maxParticles = max;
+
+    this.idToIndex = new Map();
+    this.freeSlots = [];
+    for (let i = max - 1; i >= 0; i--) {
+      this.freeSlots.push(i);
+    }
+    this.highWater = 0;
+    this.dirty = false;
+
+    const attr = (size: number): InstancedBufferAttribute =>
+      new three.InstancedBufferAttribute(new Float32Array(max * size), size);
+
+    this.aOffset = attr(3);
+    this.aColor = attr(3);
+    this.aAlpha = attr(1);
+    this.aScale = attr(1);
+    this.aRotation = attr(1);
+    this.aTexID = attr(1);
+
+    const base = new three.PlaneGeometry(1, 1);
+    const geometry = new three.InstancedBufferGeometry();
+
+    geometry.index = base.index;
+    geometry.setAttribute('position', base.attributes.position);
+    geometry.setAttribute('uv', base.attributes.uv);
+    geometry.setAttribute('aOffset', this.aOffset);
+    geometry.setAttribute('aColor', this.aColor);
+    geometry.setAttribute('aAlpha', this.aAlpha);
+    geometry.setAttribute('aScale', this.aScale);
+    geometry.setAttribute('aRotation', this.aRotation);
+    geometry.setAttribute('aTexID', this.aTexID);
+    geometry.instanceCount = 0;
+    this.geometry = geometry;
+
+    this.atlas = new TextureAtlas(three);
+
+    const material = new three.SpriteNodeMaterial({
+      transparent: true,
+      depthWrite: false,
+      blending: three.AdditiveBlending,
+    });
+
+    material.positionNode = attribute('aOffset');
+    material.scaleNode = attribute('aScale');
+    material.rotationNode = attribute('aRotation');
+    material.opacityNode = attribute('aAlpha');
+    this.material = material;
+    this.buildColorNode();
+
+    this.mesh = new three.Mesh(geometry, material);
+    this.mesh.frustumCulled = false;
+    container.add(this.mesh);
+  }
+
+  /**
+   * Wires the atlas texture + index into the colour node. Rebuilt whenever the
+   * atlas texture is recreated (a new texture packed in).
+   */
+  buildColorNode(): void {
+    const texID = attribute('aTexID');
+    const indexUV = vec2(texID.add(0.5).div(ATLAS_INDEX_SIZE), 0.5);
+    const tileRect = texture(this.atlas.atlasIndex, indexUV); // minU,minV,maxU,maxV
+    const tileUV = mix(tileRect.xy, tileRect.zw, uv());
+
+    this.material.colorNode = texture(this.atlas.atlasTexture, tileUV).mul(
+      attribute('aColor')
+    );
+    this.material.needsUpdate = true;
+  }
+
+  private slot(particle: Particle): number {
+    const existing = this.idToIndex.get(particle.id);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const index = this.freeSlots.pop() as number;
+
+    this.idToIndex.set(particle.id, index);
+    this.highWater = Math.max(this.highWater, index + 1);
+    this.geometry.instanceCount = this.highWater;
+
+    return index;
+  }
+
+  private write(particle: Particle): void {
+    const i = this.slot(particle);
+    const { position, color } = particle;
+
+    this.aOffset.array[i * 3 + 0] = position.x;
+    this.aOffset.array[i * 3 + 1] = position.y;
+    this.aOffset.array[i * 3 + 2] = position.z;
+    this.aColor.array[i * 3 + 0] = color.r;
+    this.aColor.array[i * 3 + 1] = color.g;
+    this.aColor.array[i * 3 + 2] = color.b;
+    this.aAlpha.array[i] = particle.alpha;
+    this.aScale.array[i] = particle.scale * particle.radius;
+    this.aRotation.array[i] = particle.rotation.z;
+
+    const body = particle.body;
+
+    if (body && body instanceof this.three.Sprite) {
+      const map = (body as Sprite).material.map;
+
+      if (map) {
+        this.aTexID.array[i] = this.atlas.register(
+          (body.material as SpriteMaterial).map!
+        );
+      }
+    }
+
+    this.dirty = true;
+  }
+
+  onParticleCreated(particle: Particle): void {
+    this.write(particle);
+  }
+
+  onParticleUpdate(particle: Particle): void {
+    this.write(particle);
+  }
+
+  onParticleDead(particle: Particle): void {
+    const index = this.idToIndex.get(particle.id);
+
+    if (index === undefined) {
+      return;
+    }
+
+    this.aScale.array[index] = 0; // zero-size => invisible
+    this.idToIndex.delete(particle.id);
+    this.freeSlots.push(index);
+    this.dirty = true;
+  }
+
+  onSystemUpdate(): void {
+    if (this.atlas.update()) {
+      this.buildColorNode(); // atlas texture recreated => rewire the node graph
+    }
+
+    if (!this.dirty) {
+      return;
+    }
+
+    for (const a of [
+      this.aOffset,
+      this.aColor,
+      this.aAlpha,
+      this.aScale,
+      this.aRotation,
+      this.aTexID,
+    ]) {
+      a.needsUpdate = true;
+    }
+
+    this.dirty = false;
+  }
+
+  destroy(): void {
+    this.container.remove(this.mesh);
+    this.geometry.dispose();
+    this.material.dispose();
+    this.atlas.destroy();
+  }
+}

--- a/src/webgpu/index.ts
+++ b/src/webgpu/index.ts
@@ -1,0 +1,8 @@
+// three-nebula/webgpu — renderers that require three's WebGPURenderer.
+//
+// This entry pulls in node-material / TSL code (three/webgpu, three/tsl) which
+// must NOT leak into the core WebGL bundle, so it is a separate subpath export.
+//
+//   import { GPURenderer } from 'three-nebula/webgpu';   // WebGPU host
+//
+export { default as GPURenderer } from './GPURenderer';

--- a/src/webgpu/public.d.ts
+++ b/src/webgpu/public.d.ts
@@ -10,8 +10,15 @@
 //
 // The relative imports below resolve identically from `src/webgpu/` and from
 // the copied location `dist/types/webgpu/` (same depth to their siblings), so
-// no rewriting is needed on copy. `tsconfig.webgpu.json` type-checks this file
-// against a usage sample to catch drift from the real class.
+// no rewriting is needed on copy.
+//
+// Guarding: `tsconfig.webgpu.json` checks this file is valid and compiles a
+// real usage sample (construct -> System.addRenderer -> dispose). It does NOT
+// diff against the real class — resolving that class's type forces tsc to
+// evaluate the TSL graph, which hangs (the very reason we hand-author here).
+// Fidelity of the public members is exercised at runtime by
+// test/webgpu/GPURenderer.spec.js. When you change a public member on the real
+// GPURenderer, update this file too.
 
 import type { InstancedBufferGeometry, Object3D } from 'three';
 import type { Mesh, SpriteNodeMaterial } from 'three/webgpu';

--- a/src/webgpu/public.d.ts
+++ b/src/webgpu/public.d.ts
@@ -1,0 +1,56 @@
+// Hand-authored public declaration for the `three-nebula/webgpu` entry.
+//
+// Why hand-authored: `GPURenderer`'s implementation builds a TSL node graph
+// (`three/tsl`), whose generated types are so large that `tsc`'s declaration
+// emit for the real `index.ts` blows past the "union type too complex to
+// represent" ceiling and effectively hangs (>4 min, killed before emit). The
+// public surface, however, is small and stable — none of it is TSL — so we
+// describe it here and the build copies this file verbatim to
+// `dist/types/webgpu/index.d.ts` (see scripts/build-webgpu-types.mjs).
+//
+// The relative imports below resolve identically from `src/webgpu/` and from
+// the copied location `dist/types/webgpu/` (same depth to their siblings), so
+// no rewriting is needed on copy. `tsconfig.webgpu.json` type-checks this file
+// against a usage sample to catch drift from the real class.
+
+import type { InstancedBufferGeometry, Object3D } from 'three';
+import type { Mesh, SpriteNodeMaterial } from 'three/webgpu';
+import type Particle from '../core/Particle';
+import BaseRenderer from '../renderer/BaseRenderer';
+
+export interface GPURendererOptions {
+  /** Upper bound on simultaneously-live particles (instance buffer size). */
+  maxParticles?: number;
+}
+
+/**
+ * WebGPU batched particle renderer — the node/TSL counterpart of the GLSL
+ * `GPURenderer`. Draws every particle as a camera-facing instanced quad
+ * (`SpriteNodeMaterial`) in a single call. Requires the host to render with
+ * three's `WebGPURenderer`; pass the `three/webgpu` namespace as `three`.
+ */
+export declare class GPURenderer extends BaseRenderer {
+  constructor(
+    container: Object3D,
+    three: typeof import('three/webgpu'),
+    options?: GPURendererOptions
+  );
+
+  three: typeof import('three/webgpu');
+  container: Object3D;
+  maxParticles: number;
+
+  mesh: Mesh;
+  material: SpriteNodeMaterial;
+  geometry: InstancedBufferGeometry;
+
+  /** Rewires the atlas texture + index into the colour node after a rebuild. */
+  buildColorNode(): void;
+
+  onParticleCreated(particle: Particle): void;
+  onParticleUpdate(particle: Particle): void;
+  onParticleDead(particle: Particle): void;
+  onSystemUpdate(): void;
+
+  destroy(): void;
+}

--- a/test/webgpu/GPURenderer.spec.js
+++ b/test/webgpu/GPURenderer.spec.js
@@ -1,0 +1,92 @@
+import * as THREE from 'three/webgpu';
+
+import { GPURenderer } from '../../src/webgpu';
+import chai from 'chai';
+import domino from 'domino';
+
+const { assert } = chai;
+
+// The renderer creates a canvas for its atlas; give it a DOM. domino throws on
+// getContext('2d'), so stub createElement('canvas') with a minimal fake canvas
+// + 2d context (only what the atlas touches).
+global.window = domino.createWindow();
+global.document = window.document;
+
+const realCreateElement = document.createElement.bind(document);
+
+document.createElement = tag => {
+  if (tag !== 'canvas') {
+    return realCreateElement(tag);
+  }
+
+  const canvas = { width: 0, height: 0, style: {}, remove() {} };
+
+  canvas.getContext = () => ({ canvas, drawImage() {}, clearRect() {} });
+
+  return canvas;
+};
+
+const build = () => {
+  const scene = new THREE.Scene();
+
+  return {
+    scene,
+    renderer: new GPURenderer(scene, THREE, { maxParticles: 100 }),
+  };
+};
+
+// Environment-independent structural guard for the WebGPU renderer's node graph
+// and buffer layout (per spec 07 — WebGPU can't join the pixel golden master,
+// so we snapshot construction instead of rendering).
+describe('webgpu -> GPURenderer', () => {
+  it('constructs an instanced batched renderer wired for WebGPU', () => {
+    const { scene, renderer } = build();
+
+    assert.instanceOf(renderer.material, THREE.SpriteNodeMaterial);
+    assert.strictEqual(renderer.material.blending, THREE.AdditiveBlending);
+    assert.isTrue(renderer.material.transparent);
+    assert.isFalse(renderer.material.depthWrite);
+
+    for (const node of [
+      'positionNode',
+      'scaleNode',
+      'rotationNode',
+      'opacityNode',
+      'colorNode',
+    ]) {
+      assert.isOk(renderer.material[node], `${node} should be wired`);
+    }
+
+    assert.include(scene.children, renderer.mesh);
+    assert.isFalse(renderer.mesh.frustumCulled);
+  });
+
+  it('lays out the per-instance attributes the shader reads', () => {
+    const { renderer } = build();
+    const expected = {
+      aOffset: 3,
+      aColor: 3,
+      aAlpha: 1,
+      aScale: 1,
+      aRotation: 1,
+      aTexID: 1,
+    };
+
+    for (const [name, itemSize] of Object.entries(expected)) {
+      const attribute = renderer.geometry.getAttribute(name);
+
+      assert.isOk(attribute, `${name} attribute should exist`);
+      assert.strictEqual(attribute.itemSize, itemSize, `${name} itemSize`);
+      assert.instanceOf(attribute, THREE.InstancedBufferAttribute);
+    }
+  });
+
+  it('sets up a texture atlas (CanvasTexture + float index) for multi-texture', () => {
+    const { renderer } = build();
+
+    assert.instanceOf(renderer.atlas.atlasTexture, THREE.CanvasTexture);
+    assert.instanceOf(renderer.atlas.atlasIndex, THREE.DataTexture);
+    // Mipmaps on: the #293 fix regenerates them so large tiles don't alias.
+    assert.isTrue(renderer.atlas.atlasTexture.generateMipmaps);
+  });
+});

--- a/test/webgpu/public.type-check.ts
+++ b/test/webgpu/public.type-check.ts
@@ -1,0 +1,25 @@
+// Validity guard for the hand-authored `src/webgpu/public.d.ts` (the published
+// `three-nebula/webgpu` types). Type-checked by `tsconfig.webgpu.json` — never
+// executed.
+//
+// It deliberately does NOT import the real `src/webgpu/GPURenderer`: that module
+// builds a TSL node graph whose types are too complex for the compiler and would
+// re-introduce the multi-minute hang this whole approach exists to avoid. So this
+// checks the declaration is well-formed and models real consumer usage
+// (construct + hand off to the System + dispose). Runtime behaviour and the real
+// class's shape are covered separately by test/webgpu/GPURenderer.spec.js.
+
+import { GPURenderer } from '../../src/webgpu/public';
+import type { GPURendererOptions } from '../../src/webgpu/public';
+import System from '../../src/core/System';
+import { Scene } from 'three';
+import * as THREE_WEBGPU from 'three/webgpu';
+
+const options: GPURendererOptions = { maxParticles: 100 };
+const renderer = new GPURenderer(new Scene(), THREE_WEBGPU, options);
+
+// Must type-check => the declaration extends BaseRenderer, so the System accepts it.
+new System().addRenderer(renderer);
+
+renderer.onSystemUpdate();
+renderer.destroy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,9 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // The WebGPU entry pulls in three/webgpu + three/tsl, whose enormous type
+  // declarations slow the whole-project typecheck. It is checked/built
+  // separately via tsconfig.webgpu.json so the core typecheck stays fast.
+  "exclude": ["src/webgpu"]
 }

--- a/tsconfig.webgpu.json
+++ b/tsconfig.webgpu.json
@@ -1,0 +1,12 @@
+{
+  // Drift/validity check for the hand-authored webgpu declaration. Type-checks
+  // the published `src/webgpu/public.d.ts` against a usage sample. It never
+  // touches the TSL-heavy `src/webgpu/GPURenderer/*`, so it stays fast (unlike
+  // declaration emit for the real class, which hangs on TSL's type complexity).
+  // `exclude: []` overrides the base config's `exclude: ["src/webgpu"]` so the
+  // declaration under src/webgpu is visible.
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["src/webgpu/public.d.ts", "test/webgpu/public.type-check.ts"],
+  "exclude": []
+}

--- a/tsconfig.webgpu.json
+++ b/tsconfig.webgpu.json
@@ -1,10 +1,11 @@
 {
-  // Drift/validity check for the hand-authored webgpu declaration. Type-checks
-  // the published `src/webgpu/public.d.ts` against a usage sample. It never
-  // touches the TSL-heavy `src/webgpu/GPURenderer/*`, so it stays fast (unlike
-  // declaration emit for the real class, which hangs on TSL's type complexity).
-  // `exclude: []` overrides the base config's `exclude: ["src/webgpu"]` so the
-  // declaration under src/webgpu is visible.
+  // Validity check for the hand-authored webgpu declaration: confirms
+  // `src/webgpu/public.d.ts` is valid and that a real usage sample compiles.
+  // It deliberately never touches the TSL-heavy `src/webgpu/GPURenderer/*`, so
+  // it stays fast — but that also means it can't diff the declaration against
+  // the real class (resolving that type hangs tsc on TSL complexity); the
+  // runtime spec covers public-member fidelity. `exclude: []` overrides the
+  // base config's `exclude: ["src/webgpu"]` so the declaration is visible.
   "extends": "./tsconfig.json",
   "compilerOptions": { "noEmit": true },
   "include": ["src/webgpu/public.d.ts", "test/webgpu/public.type-check.ts"],

--- a/vite.sandbox.config.js
+++ b/vite.sandbox.config.js
@@ -11,9 +11,14 @@ const root = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   root: resolve(root, 'sandbox'),
   resolve: {
-    alias: {
-      'three-nebula': resolve(root, 'src/index.ts'),
-    },
+    alias: [
+      // More specific first: the /webgpu subpath maps to its own entry.
+      {
+        find: /^three-nebula\/webgpu$/,
+        replacement: resolve(root, 'src/webgpu/index.ts'),
+      },
+      { find: /^three-nebula$/, replacement: resolve(root, 'src/index.ts') },
+    ],
   },
   server: { port: 5000, open: true },
 });

--- a/vite.webgpu.config.js
+++ b/vite.webgpu.config.js
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+// Separate build for the `three-nebula/webgpu` entry. Kept apart from the core
+// build so node-material / TSL code (three/webgpu, three/tsl) never leaks into
+// the core WebGL bundle. `emptyOutDir: false` preserves the core build's dist
+// output (this runs after `vite build`). No UMD — WebGPU is ESM/CJS only.
+export default defineConfig({
+  build: {
+    target: 'es2020',
+    sourcemap: true,
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(root, 'src/webgpu/index.ts'),
+      formats: ['es', 'cjs'],
+      fileName: format =>
+        format === 'es' ? 'three-nebula-webgpu.mjs' : 'three-nebula-webgpu.cjs',
+    },
+    rollupOptions: {
+      external: ['three', 'three/webgpu', 'three/tsl'],
+    },
+  },
+});


### PR DESCRIPTION
Adds first-class WebGPU support to three-nebula. Integration branch for the WebGPU workstream — squash-merges #303 plus follow-ups.

## What's included

### Level 0 — CPU-material renderers under WebGPURenderer
Existing `SpriteRenderer` / `MeshRenderer` work unchanged when the host renders with three's `WebGPURenderer`. Validated in sandbox experiments.

### Level 1 — the `GPURenderer` (new)
A node/TSL batched particle renderer, published at the `three-nebula/webgpu` subpath:

- `import { GPURenderer } from 'three-nebula/webgpu'`
- Draws every particle as a camera-facing instanced quad (`SpriteNodeMaterial`) in a single call; per-instance position/colour/alpha/scale/rotation/texture via instanced attributes.
- Multi-texture support via a packed atlas (potpack → `CanvasTexture` + a float index `DataTexture`), including the #293 mipmap fix so large tiles don't alias.
- **World-scale sizing** (`scale * radius`, matching `SpriteRenderer`) rather than the GLSL renderer's `gl_PointSize` model — see the spec note.
- **Parity-validated** against `SpriteRenderer` on a real GPU (single- and multi-texture) using the `GpuRenderer` example data as a golden reference.

## Packaging
- Separate vite lib build → `dist/three-nebula-webgpu.{mjs,cjs}` (externals: `three`, `three/webgpu`, `three/tsl`); core WebGL bundle untouched.
- `exports["./webgpu"]` wired for types + import + require.
- `src/webgpu` is excluded from the core typecheck/emit so `three/webgpu`'s huge declarations don't slow it down.

## Types (hand-authored — see note)
`tsc` declaration emit for the real `GPURenderer` **can't run**: its TSL node graph produces types that exceed the compiler's "union type too complex to represent" ceiling, so emit hangs (>4 min) and is killed before producing anything. Instead the small, stable public surface is hand-authored in `src/webgpu/public.d.ts` and copied verbatim to `dist/types/webgpu/index.d.ts` at build. `tsconfig.webgpu.json` validates the declaration + a usage sample (it can't diff against the real class — that reintroduces the hang, verified); runtime member fidelity is covered by the spec. This is manually-synced by design and documented at the source of truth.

## Testing
WebGPU can't join the deterministic SwiftShader golden master (both candidate paths empirically fail — recorded in the spec). Guarded instead by node-graph/attribute-layout snapshot tests + real-GPU headed validation.

## Out of scope
Level 2 (GPU-compute simulation) — deliberately deferred; it breaks determinism and entangles with the schema/determinism roadmap items.

## Commits
- WebGPU Level 0 — CPU-material renderers under WebGPURenderer
- Record WebGPU testing findings (deterministic VR paths ruled out)
- WebGPU GPURenderer — three-nebula/webgpu (Level 1, parity-validated) (#303)
- Align public type surface with impl (atlas) + correct drift-guard docs (post-review)