### PR TITLE
Merge release/12.1.0 back into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## `v12.1.0` - 2026-08-09
+
+Adds optional WebGPU support via a new `three-nebula/webgpu` entry point. This is a backward-compatible, additive release — the core package and every existing renderer are unchanged, and the supported `three` range for the core is the same.
+
+### Added
+
+- **A WebGPU `GPURenderer`, published at the `three-nebula/webgpu` subpath.** A node/TSL batched particle renderer that draws every particle as a camera-facing instanced quad (`SpriteNodeMaterial`) in a single draw call, packing multiple textures into an atlas. Import it with `import { GPURenderer } from 'three-nebula/webgpu'` and use it under three's `WebGPURenderer`. Validated for visual parity with `SpriteRenderer`.
+  - **The WebGPU entry requires a modern `three`** — one that ships `three/webgpu` and `three/tsl` (roughly `three` r167+). This applies only if you import `three-nebula/webgpu`; the core `three-nebula` package's supported `three` range is unchanged.
+  - Its type declarations are hand-authored and shipped at the subpath (three's TSL node types are too complex for `tsc`'s declaration emit to serialize).
+- The existing CPU-material renderers (`SpriteRenderer`, `MeshRenderer`) also work unchanged under three's `WebGPURenderer`.
+
 ## `v12.0.1` - 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - The ability to instantiate `three-nebula` particle systems from JSON objects
 - The ability to create particle systems from sprites as well as 3D meshes
 - Many kinds of particle behaviours and initializers
+- Optional WebGPU rendering via a batched `GPURenderer` at [`three-nebula/webgpu`](#webgpu)
 
 ## Installation
 
@@ -276,6 +277,25 @@ System.fromJSONAsync(json, THREE).then(system => {
   console.log(system);
 });
 ```
+
+### WebGPU
+
+`three-nebula` ships an optional batched `GPURenderer` for WebGPU at the `three-nebula/webgpu` entry point. It draws every particle as a camera-facing instanced quad in a single draw call and packs multiple textures into an atlas, and is a drop-in alternative to `SpriteRenderer` when your app renders with three's `WebGPURenderer`:
+
+```javascript
+import * as THREE from 'three/webgpu';
+import System, { Emitter /* … initializers, behaviours … */ } from 'three-nebula';
+import { GPURenderer } from 'three-nebula/webgpu';
+
+const renderer = new THREE.WebGPURenderer();
+await renderer.init();
+
+const system = new System();
+system.addRenderer(new GPURenderer(scene, THREE));
+// build emitters as usual, then drive system.update() from your render loop
+```
+
+> **Requires a modern `three`.** The WebGPU entry point imports `three/webgpu` and `three/tsl`, which only exist in recent `three` releases (roughly r167+). This requirement applies **only** if you import `three-nebula/webgpu` — the core `three-nebula` package's supported `three` range is unchanged.
 
 ### Script Tag
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three-nebula",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three-nebula",
-      "version": "12.0.1",
+      "version": "12.1.0",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.61.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-nebula",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "description": "WebGL based 3D particle engine",
   "main": "./dist/three-nebula.cjs",
   "module": "./dist/three-nebula.mjs",


### PR DESCRIPTION
Back-merge of the 12.1.0 release (version bump + CHANGELOG + README) into develop, per git-flow.