### PR TITLE
Stage 2 — nested child emitters, instancing & orphan lifecycle

### DIFF
--- a/sandbox/experiments/emitter-hierarchy/index.html
+++ b/sandbox/experiments/emitter-hierarchy/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Emitter Hierarchy — sparks leaving smoke trails</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -1,0 +1,99 @@
+import * as THREE from 'three';
+import System, {
+  Alpha,
+  Body,
+  Color,
+  Emitter,
+  Force,
+  Life,
+  Mass,
+  RadialVelocity,
+  Radius,
+  Rate,
+  Scale,
+  Span,
+  GPURenderer,
+  Vector3D,
+} from 'three-nebula';
+import { run } from '/common/run.js';
+
+// Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
+// outward; each spark rides a child "smoke" emitter (inherit.position: 'always',
+// orphanPolicy: 'detach') so the smoke follows its spark and lives on after the
+// spark dies. One child node → one live instance per spark, all recycled through
+// the Stage 1 pool.
+
+const createSprite = color => {
+  const map = new THREE.TextureLoader().load('/assets/dot.png');
+
+  return new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map,
+      color,
+      blending: THREE.AdditiveBlending,
+      fog: true,
+    })
+  );
+};
+
+// The child: a slow, greying puff that trails whichever spark spawned it.
+const createSmokeTrail = () => {
+  const smoke = new Emitter();
+
+  smoke
+    .setRate(new Rate(new Span(1, 2), new Span(0.02, 0.04)))
+    .setInitializers([
+      new Mass(1),
+      new Life(0.6, 1.1),
+      new Body(createSprite(0x888888)),
+      new Radius(16, 32),
+      new RadialVelocity(15, new Vector3D(0, 1, 0), 30),
+    ])
+    .setBehaviours([
+      new Alpha(0.35, 0),
+      new Scale(0.5, 1.6),
+      new Color('#aaaaaa', '#222222'),
+    ]);
+
+  // Follow the parent spark every frame; let emitted smoke outlive the spark.
+  smoke.inherit = { position: 'always', rotation: 'none', scale: 'none' };
+  smoke.orphanPolicy = 'detach';
+  smoke.emit(Infinity, Infinity);
+
+  return smoke;
+};
+
+// The parent: bright, fast sparks under gravity, each carrying a smoke child.
+const createSparks = () => {
+  const sparks = new Emitter();
+
+  sparks
+    .setRate(new Rate(new Span(2, 4), new Span(0.06, 0.1)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1.1, 1.7),
+      new Body(createSprite(0xffcc33)),
+      new Radius(26, 46),
+      new RadialVelocity(220, new Vector3D(0, 1, 0), 55),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Scale(1, 0.25),
+      new Color('#fffb00', '#ff3c00'),
+      new Force(0, -140, 0),
+    ]);
+
+  sparks.addChild(createSmokeTrail());
+
+  return sparks.emit();
+};
+
+const init = async ({ scene }) => {
+  const system = new System();
+
+  return system
+    .addEmitter(createSparks())
+    .addRenderer(new GPURenderer(scene, THREE));
+};
+
+run(init, { shouldRotateCamera: false, shouldAddCameraControls: true });

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,11 @@
     <nav>
       <ul>
         <li>
+          <a href="experiments/emitter-hierarchy/index.html">
+            Emitter Hierarchy — sparks leaving smoke trails (child emitters)
+          </a>
+        </li>
+        <li>
           <a href="experiments/determinism/index.html">
             Determinism — same seed, same result (toggle "desync" to diverge)
           </a>

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -1,11 +1,13 @@
 import EventDispatcher, {
   EMITTER_ADDED,
   EMITTER_REMOVED,
+  PARTICLE_DEAD,
   SYSTEM_UPDATE,
   SYSTEM_UPDATE_AFTER,
 } from '../events';
 
 import {
+  DEFAULT_MAX_DEPTH,
   DEFAULT_MAX_EMITTER_INSTANCES,
   DEFAULT_MAX_SUB_STEPS,
   DEFAULT_SYSTEM_DELTA,
@@ -68,6 +70,12 @@ export default class System {
   _emitterPoolHits: number;
   _emitterPoolMisses: number;
   _warnedInstanceOverflow: boolean;
+  // Hard recursion cap on the emitter tree (spec 01, Stage 2), enforced when an
+  // emitter is added. Detached child instances outlive their dead parent to let
+  // their particles drain (orphanPolicy 'detach'); the System advances them each
+  // frame and releases them once empty.
+  maxEmitterDepth: number;
+  _detached: Emitter[];
 
   constructor(
     preParticles: number = POOL_MAX,
@@ -91,6 +99,8 @@ export default class System {
     this._emitterPoolHits = 0;
     this._emitterPoolMisses = 0;
     this._warnedInstanceOverflow = false;
+    this.maxEmitterDepth = DEFAULT_MAX_DEPTH;
+    this._detached = [];
   }
 
   /**
@@ -119,6 +129,11 @@ export default class System {
     const warm = node._freeInstances.length > 0;
     const inst = node.acquireInstance(parentParticle);
 
+    // Parent the instance to the System (not the spawning emitter) so its own
+    // createParticle/update dispatch through the System's event stream — the same
+    // path top-level emitters use, so child particles reach the renderers (B1).
+    inst.parent = this;
+
     warm ? this._emitterPoolHits++ : this._emitterPoolMisses++;
     this._liveEmitterInstances++;
 
@@ -132,6 +147,81 @@ export default class System {
   releaseEmitterInstance(inst: Emitter): void {
     (inst._template as Emitter).releaseInstance(inst);
     this._liveEmitterInstances--;
+  }
+
+  /**
+   * Detaches a child instance from its dead parent: it stops emitting but keeps
+   * updating so its already-emitted particles live out their lives, then is
+   * released once drained (see `_updateDetached`). This is the `detach` policy.
+   */
+  _detachInstance(inst: Emitter): void {
+    inst.isEmitting = false;
+    inst._parentParticle = null;
+    this._detached.push(inst);
+  }
+
+  /**
+   * Kills a child instance with its parent (the `kill` policy): recursively kills
+   * its own descendants, expires its particles (dispatching PARTICLE_DEAD so
+   * renderers free them), then releases it immediately.
+   */
+  _killInstance(inst: Emitter): void {
+    inst.isEmitting = false;
+
+    if (inst.activeChildren.size) {
+      inst.activeChildren.forEach(instances => {
+        for (let i = 0; i < instances.length; i++) {
+          this._killInstance(instances[i]);
+        }
+      });
+      inst.activeChildren.clear();
+    }
+
+    let i = inst.particles.length;
+
+    while (i--) {
+      const particle = inst.particles[i];
+
+      this.dispatch(PARTICLE_DEAD, particle);
+      this.pool.expire(particle.reset());
+    }
+
+    inst.particles.length = 0;
+    this.releaseEmitterInstance(inst);
+  }
+
+  /**
+   * Advances detached instances (parents already dead) and releases each once it
+   * has fully drained. Runs after the emitter walk so freshly-detached instances
+   * still tick this frame. Flushes SYSTEM_UPDATE if any still hold particles so
+   * renderer buffers pick up their movement.
+   */
+  _updateDetached(time: number): void {
+    if (!this._detached.length) {
+      return;
+    }
+
+    let flushed = false;
+    let i = this._detached.length;
+
+    while (i--) {
+      const inst = this._detached[i];
+
+      inst.update(time);
+
+      if (inst.particles.length) {
+        flushed = true;
+      }
+
+      if (inst.particles.length === 0 && inst.activeChildren.size === 0) {
+        this._detached.splice(i, 1);
+        this.releaseEmitterInstance(inst);
+      }
+    }
+
+    if (flushed) {
+      this.dispatch(SYSTEM_UPDATE);
+    }
   }
 
   /**
@@ -205,6 +295,9 @@ export default class System {
     // Derive this emitter's deterministic seed from the system seed + its index
     // (stable across runs since emitters load in JSON order).
     emitter.reseed(this.seed, index);
+    // Assign tree-path node ids across the whole subtree (and enforce the depth
+    // cap) now that we know this emitter's root index.
+    emitter._assignNodeIds(`${index}`, 0, this.maxEmitterDepth);
 
     this.emitters.push(emitter);
     this.dispatch(EMITTER_ADDED, emitter);
@@ -295,6 +388,10 @@ export default class System {
           emitter.update(d);
           emitter.particles.length && this.dispatch(SYSTEM_UPDATE);
         }
+
+        // Advance detached child instances (dead parents) so their particles
+        // drain, then release the empty ones.
+        this._updateDetached(d);
       }
 
       this.dispatch(SYSTEM_UPDATE_AFTER);

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -139,6 +139,16 @@ export const DEFAULT_MAX_SUB_STEPS = 6;
 export const DEFAULT_MAX_EMITTER_INSTANCES = 2000;
 
 /**
+ * The default hard recursion limit on the emitter tree (spec 01, Stage 2). A
+ * self-triggering or accidentally deep hierarchy retains every ancestor instance
+ * until its last descendant dies, so an unbounded chain leaks until it exhausts
+ * memory. Trees deeper than this are rejected when added to a System.
+ *
+ * @type {number}
+ */
+export const DEFAULT_MAX_DEPTH = 4;
+
+/**
  * @desc The types of initializers supported by the System.fromJSON method.
  * @type {array<string>}
  */

--- a/src/core/fromJSON.ts
+++ b/src/core/fromJSON.ts
@@ -17,6 +17,7 @@ import type {
 import Rate from '../initializer/Rate';
 import type System from './System';
 import type Emitter from '../emitter/Emitter';
+import type { InheritConfig, OrphanPolicy } from '../emitter/Emitter';
 import type InitializerBase from '../initializer/Initializer';
 import type BehaviourBase from '../behaviour/Behaviour';
 
@@ -101,6 +102,12 @@ export interface EmitterJSON {
   totalEmitTimes?: number;
   life?: number;
   damping?: number;
+  // Emitter hierarchy (spec 01, Stage 2), all additive: `children` nests emitter
+  // templates (absent = a flat leaf emitter, i.e. today's schema); `inherit` and
+  // `orphanPolicy` only apply to a nested child.
+  children?: EmitterJSON[];
+  inherit?: Partial<InheritConfig>;
+  orphanPolicy?: OrphanPolicy;
 }
 
 export interface SystemJSON {
@@ -175,6 +182,57 @@ const makeBehaviours = (items: ItemJSON[]): BehaviourBase[] => {
 };
 
 /**
+ * Builds an emitter (and, recursively, its child templates) from JSON. Children
+ * are wired as `childNodes` rather than added to the System — only the root is
+ * added, which assigns the whole subtree's node ids and enforces the depth cap.
+ */
+const buildEmitter = (
+  data: EmitterJSON,
+  THREE: ThreeApi,
+  Emitter: EmitterConstructor
+): Emitter => {
+  const emitter = new Emitter();
+  const {
+    rate,
+    rotation,
+    initializers,
+    behaviours,
+    emitterBehaviours = [],
+    position,
+    totalEmitTimes = Infinity,
+    life = Infinity,
+    damping = DEFAULT_DAMPING,
+    children = [],
+    inherit,
+    orphanPolicy,
+  } = data;
+
+  emitter.damping = damping;
+  emitter
+    .setRate(makeRate(rate))
+    .setRotation(rotation)
+    .setInitializers(makeInitializers(initializers, THREE))
+    .setBehaviours(makeBehaviours(behaviours))
+    .setEmitterBehaviours(makeBehaviours(emitterBehaviours))
+    .setPosition(position)
+    .emit(totalEmitTimes, life);
+
+  if (inherit) {
+    emitter.inherit = { ...emitter.inherit, ...inherit };
+  }
+
+  if (orphanPolicy) {
+    emitter.orphanPolicy = orphanPolicy;
+  }
+
+  children.forEach(child =>
+    emitter.addChild(buildEmitter(child, THREE, Emitter))
+  );
+
+  return emitter;
+};
+
+/**
  * Creates a System instance from a JSON object.
  *
  * @deprecated Use fromJSONAsync instead.
@@ -195,32 +253,9 @@ export default (
   // set system.preParticles to the three namespace. Fixed to match the async path.
   const system = new System(preParticles, integrationType);
 
-  emitters.forEach(data => {
-    const emitter = new Emitter();
-    const {
-      rate,
-      rotation,
-      initializers,
-      behaviours,
-      emitterBehaviours = [],
-      position,
-      totalEmitTimes = Infinity,
-      life = Infinity,
-      damping = DEFAULT_DAMPING,
-    } = data;
-
-    emitter.damping = damping;
-    emitter
-      .setRate(makeRate(rate))
-      .setRotation(rotation)
-      .setInitializers(makeInitializers(initializers, THREE))
-      .setBehaviours(makeBehaviours(behaviours))
-      .setEmitterBehaviours(makeBehaviours(emitterBehaviours))
-      .setPosition(position)
-      .emit(totalEmitTimes, life);
-
-    system.addEmitter(emitter);
-  });
+  emitters.forEach(data =>
+    system.addEmitter(buildEmitter(data, THREE, Emitter))
+  );
 
   return system;
 };

--- a/src/core/fromJSONAsync.ts
+++ b/src/core/fromJSONAsync.ts
@@ -135,79 +135,88 @@ const makeBehaviours = (items: ItemJSON[]): Promise<BehaviourBase[]> =>
     });
   });
 
+/**
+ * Builds one emitter (and, recursively, its child templates) from JSON, awaiting
+ * each node's async initializer/texture loads. Children are wired as `childNodes`
+ * via addChild; only the root is added to the System (which assigns node ids and
+ * enforces the depth cap). Mirrors the sync `buildEmitter`.
+ */
+const buildEmitterAsync = (
+  data: EmitterJSON,
+  Emitter: EmitterConstructor,
+  THREE: ThreeApi,
+  shouldAutoEmit: boolean | undefined
+): Promise<Emitter> => {
+  const emitter = new Emitter();
+  const {
+    rate,
+    rotation,
+    initializers,
+    behaviours,
+    emitterBehaviours = [],
+    position,
+    totalEmitTimes = Infinity,
+    life = Infinity,
+    damping = DEFAULT_DAMPING,
+    children = [],
+    inherit,
+    orphanPolicy,
+  } = data;
+
+  emitter.damping = damping;
+  emitter.setRate(makeRate(rate)).setRotation(rotation).setPosition(position);
+
+  if (inherit) {
+    emitter.inherit = { ...emitter.inherit, ...inherit };
+  }
+
+  if (orphanPolicy) {
+    emitter.orphanPolicy = orphanPolicy;
+  }
+
+  return makeInitializers(initializers, THREE)
+    .then(madeInitializers => {
+      emitter.setInitializers(madeInitializers);
+
+      return makeBehaviours(behaviours);
+    })
+    .then(madeBehaviours => {
+      emitter.setBehaviours(madeBehaviours);
+
+      return makeBehaviours(emitterBehaviours);
+    })
+    .then(madeEmitterBehaviours => {
+      emitter.setEmitterBehaviours(madeEmitterBehaviours);
+
+      // Build children in order (each may itself load textures asynchronously).
+      return Promise.all(
+        children.map(child =>
+          buildEmitterAsync(child, Emitter, THREE, shouldAutoEmit)
+        )
+      );
+    })
+    .then(childEmitters => {
+      childEmitters.forEach(child => emitter.addChild(child));
+
+      return shouldAutoEmit
+        ? emitter.emit(totalEmitTimes, life)
+        : emitter.setTotalEmitTimes(totalEmitTimes).setLife(life);
+    });
+};
+
 const makeEmitters = (
   emitters: EmitterJSON[],
   Emitter: EmitterConstructor,
   THREE: ThreeApi,
   shouldAutoEmit: boolean | undefined
 ): Promise<Emitter[]> =>
-  new Promise((resolve, reject) => {
-    if (!emitters.length) {
-      return resolve([]);
-    }
-
-    const numberOfEmitters = emitters.length;
-
-    if (!numberOfEmitters) {
-      return resolve([]);
-    }
-
-    // Each built emitter is written at its ORIGINAL index, and we resolve once every
-    // slot is filled — so system.emitters preserves the input order regardless of how
-    // the emitters' async initializer/texture loads interleave. (Previously emitters
-    // were pushed as they completed, i.e. in load-resolution order.)
-    const madeEmitters: Emitter[] = new Array(numberOfEmitters);
-    let madeCount = 0;
-
-    emitters.forEach((data, index) => {
-      const emitter = new Emitter();
-      const {
-        rate,
-        rotation,
-        initializers,
-        behaviours,
-        emitterBehaviours = [],
-        position,
-        totalEmitTimes = Infinity,
-        life = Infinity,
-        damping = DEFAULT_DAMPING,
-      } = data;
-
-      emitter.damping = damping;
-      emitter
-        .setRate(makeRate(rate))
-        .setRotation(rotation)
-        .setPosition(position);
-
-      makeInitializers(initializers, THREE)
-        .then(madeInitializers => {
-          emitter.setInitializers(madeInitializers);
-
-          return makeBehaviours(behaviours);
-        })
-        .then(madeBehaviours => {
-          emitter.setBehaviours(madeBehaviours);
-
-          return makeBehaviours(emitterBehaviours);
-        })
-        .then(madeEmitterBehaviours => {
-          emitter.setEmitterBehaviours(madeEmitterBehaviours);
-
-          return Promise.resolve(emitter);
-        })
-        .then(emitter => {
-          madeEmitters[index] = shouldAutoEmit
-            ? emitter.emit(totalEmitTimes, life)
-            : emitter.setTotalEmitTimes(totalEmitTimes).setLife(life);
-          madeCount += 1;
-
-          if (madeCount === numberOfEmitters) {
-            return resolve(madeEmitters);
-          }
-        })
-        .catch(reject);
-    });
-  });
+  // Promise.all preserves input order, so system.emitters stays in JSON order
+  // regardless of how the nested async texture loads interleave.
+  Promise.all(
+    emitters.map(data =>
+      buildEmitterAsync(data, Emitter, THREE, shouldAutoEmit)
+    )
+  );
 
 /**
  * Creates a System instance from a JSON object.

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -4,7 +4,12 @@ import {
   DEFAULT_DAMPING,
   DEFAULT_EMITTER_INDEX,
   DEFAULT_EMITTER_RATE,
+  DEFAULT_INHERIT_POSITION,
+  DEFAULT_INHERIT_ROTATION,
+  DEFAULT_INHERIT_SCALE,
+  DEFAULT_ORPHAN_POLICY,
 } from './constants';
+import { DEFAULT_MAX_DEPTH } from '../core/constants';
 import EventDispatcher, {
   EMITTER_DEAD,
   PARTICLE_CREATED,
@@ -30,6 +35,50 @@ interface Vector3Props {
   y?: number;
   z?: number;
 }
+
+/**
+ * How a child emitter's transform relates to its parent particle, per channel:
+ * `always` tracks it every frame (trails, attached FX), `onCreate` snapshots it
+ * once at spawn then runs free (ribbons, debris), `none` ignores it (system space).
+ */
+export type InheritMode = 'always' | 'onCreate' | 'none';
+
+export interface InheritConfig {
+  position: InheritMode;
+  rotation: InheritMode;
+  scale: InheritMode;
+}
+
+/** What becomes of a dead parent's already-emitted child particles. */
+export type OrphanPolicy = 'kill' | 'detach';
+
+/**
+ * Copies the parent particle's transform onto a child instance according to its
+ * `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
+ * per-frame call (atSpawn=false) only re-applies the continuous `always` mode.
+ * Scale inheritance is deferred to Stage 3 (it needs a per-emitter scale offset).
+ */
+const applyInheritance = (
+  inst: Emitter,
+  particle: Particle,
+  atSpawn: boolean
+): void => {
+  const { inherit } = inst;
+
+  if (
+    inherit.position === 'always' ||
+    (atSpawn && inherit.position === 'onCreate')
+  ) {
+    inst.position.copy(particle.position);
+  }
+
+  if (
+    inherit.rotation === 'always' ||
+    (atSpawn && inherit.rotation === 'onCreate')
+  ) {
+    inst.rotation.copy(particle.rotation);
+  }
+};
 
 /**
  * Emitters are the System engine's particle factories. They cause particles to
@@ -67,9 +116,15 @@ export default class Emitter extends Particle {
   // live particles rather than cumulative spawns.
   nodeId: string;
   childNodes: Emitter[];
+  inherit: InheritConfig;
+  orphanPolicy: OrphanPolicy;
   _template: Emitter | null;
   _parentParticle: Particle | null;
   _freeInstances: Emitter[];
+  // Live child instances riding each of this emitter's still-alive particles,
+  // keyed by the parent particle so they can be orphaned when it dies. On a live
+  // instance this holds its grandchildren; on a template it stays empty.
+  activeChildren: Map<Particle, Emitter[]>;
 
   constructor(properties?: Record<string, unknown>) {
     super(properties);
@@ -80,9 +135,16 @@ export default class Emitter extends Particle {
     this._spawnCount = 0;
     this.nodeId = '';
     this.childNodes = [];
+    this.inherit = {
+      position: DEFAULT_INHERIT_POSITION,
+      rotation: DEFAULT_INHERIT_ROTATION,
+      scale: DEFAULT_INHERIT_SCALE,
+    };
+    this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
     this._template = null;
     this._parentParticle = null;
     this._freeInstances = [];
+    this.activeChildren = new Map();
     this.particles = [];
     this.initializers = [];
     this.behaviours = [];
@@ -152,6 +214,8 @@ export default class Emitter extends Particle {
     inst.behaviours = this.behaviours;
     inst.emitterBehaviours = this.emitterBehaviours;
     inst.childNodes = this.childNodes;
+    inst.inherit = this.inherit;
+    inst.orphanPolicy = this.orphanPolicy;
     inst.damping = this.damping;
     inst.rate = new Rate(this.rate.numPan, this.rate.timePan);
     inst.totalEmitTimes = this.totalEmitTimes;
@@ -179,6 +243,7 @@ export default class Emitter extends Particle {
     this._spawnCount = 0;
     this.isEmitting = false;
     this.particles.length = 0;
+    this.activeChildren.clear();
     this._parentParticle = null;
     this.position.set(0, 0, 0);
     this.rotation.clear();
@@ -197,6 +262,10 @@ export default class Emitter extends Particle {
     inst._resetInstanceState();
     inst._parentParticle = parentParticle;
     inst.reseedFromParent(this.nodeId, parentParticle.id);
+    // Re-draw the emission interval from the instance's own seeded stream — the
+    // fresh Rate built in _createInstance seeded its first interval off
+    // Math.random, which would make child timing non-deterministic.
+    inst.rate.resetInterval(inst.rng);
     inst.isEmitting = true;
 
     return inst;
@@ -210,6 +279,117 @@ export default class Emitter extends Particle {
   releaseInstance(inst: Emitter): void {
     inst.isEmitting = false;
     this._freeInstances.push(inst);
+  }
+
+  /**
+   * Assigns this node's tree-path id and recurses into its children, so the whole
+   * subtree gets stable addresses (e.g. "0", "0/children/1"). Called by
+   * System.addEmitter with the emitter's array index as the root path. Enforces
+   * the hard depth cap here — the single choke point both the JSON and code paths
+   * flow through — throwing on an over-deep tree rather than leaking at runtime.
+   */
+  _assignNodeIds(
+    nodeId: string,
+    depth = 0,
+    maxDepth: number = DEFAULT_MAX_DEPTH
+  ): void {
+    if (depth > maxDepth) {
+      throw new Error(
+        `three-nebula: emitter hierarchy exceeds maxDepth (${maxDepth}) at "${nodeId}"`
+      );
+    }
+
+    this.nodeId = nodeId;
+
+    for (let i = 0; i < this.childNodes.length; i++) {
+      this.childNodes[i]._assignNodeIds(
+        `${nodeId}/children/${i}`,
+        depth + 1,
+        maxDepth
+      );
+    }
+  }
+
+  /**
+   * Nests a child emitter template under this one. The child is instanced once
+   * per particle this emitter spawns. Node ids are (re)assigned when the root is
+   * added to a System, so children may be attached in any order beforehand.
+   */
+  addChild(child: Emitter): this {
+    this.childNodes.push(child);
+
+    return this;
+  }
+
+  /**
+   * Spawns a child instance of every child node, bound to a just-created parent
+   * particle, and snapshots the parent transform for `onCreate` inheritance. The
+   * System owns the acquire (cap + accounting); a null return means the cap was
+   * hit and this child is dropped.
+   */
+  _spawnChildrenFor(particle: Particle): void {
+    const system = this.system as System;
+    const instances: Emitter[] = [];
+
+    for (let i = 0; i < this.childNodes.length; i++) {
+      const inst = system.spawnEmitterInstance(this.childNodes[i], particle);
+
+      if (!inst) {
+        continue;
+      }
+
+      applyInheritance(inst, particle, true);
+      instances.push(inst);
+    }
+
+    if (instances.length) {
+      this.activeChildren.set(particle, instances);
+    }
+  }
+
+  /**
+   * Handles the child instances riding a particle that has just died: each is
+   * either detached (its particles live on, per `detach`) or killed with it.
+   * Runs before the particle is reset so the mapping key is still valid.
+   */
+  _orphanChildrenOf(particle: Particle): void {
+    const instances = this.activeChildren.get(particle);
+
+    if (!instances) {
+      return;
+    }
+
+    const system = this.system as System;
+
+    for (let i = 0; i < instances.length; i++) {
+      const inst = instances[i];
+
+      inst.orphanPolicy === 'kill'
+        ? system._killInstance(inst)
+        : system._detachInstance(inst);
+    }
+
+    this.activeChildren.delete(particle);
+  }
+
+  /**
+   * Advances the child instances riding each still-live particle, after this
+   * emitter's own particles have moved this frame (topological order: a parent
+   * resolves before its children read its transform). Recurses via inst.update.
+   */
+  _updateChildInstances(time: number): void {
+    if (!this.activeChildren.size) {
+      return;
+    }
+
+    this.activeChildren.forEach((instances, particle) => {
+      for (let i = 0; i < instances.length; i++) {
+        const inst = instances[i];
+
+        applyInheritance(inst, particle, false);
+        inst.update(time);
+      }
+    });
   }
 
   /**
@@ -534,6 +714,11 @@ export default class Emitter extends Particle {
     this.system && this.system.dispatch(PARTICLE_CREATED, particle);
     this.bindEmitterEvent && this.dispatch(PARTICLE_CREATED, particle);
 
+    // Instance a child emitter per child node, riding this new particle.
+    if (this.childNodes.length && this.system) {
+      this._spawnChildrenFor(particle);
+    }
+
     return particle;
   }
 
@@ -592,6 +777,11 @@ export default class Emitter extends Particle {
       const particle = this.particles[i];
 
       if (particle.dead) {
+        // Detach or kill any child instances riding this particle before it is
+        // reset and returned to the pool (the map is keyed on the particle).
+        if (this.activeChildren.size) {
+          this._orphanChildrenOf(particle);
+        }
         this.system && this.system.dispatch(PARTICLE_DEAD, particle);
         this.bindEmitterEvent && this.dispatch(PARTICLE_DEAD, particle);
         // faithful to the pre-migration crash if the emitter is detached.
@@ -604,6 +794,9 @@ export default class Emitter extends Particle {
     }
 
     this.updateEmitterBehaviours(time);
+
+    // Children resolve last, after this emitter's particles have advanced.
+    this._updateChildInstances(time);
   }
 
   /**

--- a/src/emitter/constants.ts
+++ b/src/emitter/constants.ts
@@ -5,3 +5,15 @@ export const DEFAULT_BIND_EMITTER = true;
 export const DEFAULT_EMITTER_RATE = new Rate(1, 0.1);
 export const DEFAULT_BIND_EMITTER_EVENT = false;
 export const DEFAULT_EMITTER_INDEX = undefined;
+
+// Emitter hierarchy (spec 01, Stage 2). A child emitter's transform tracks its
+// parent particle per channel: position follows by default (trails/attached FX),
+// rotation and scale are left in system space unless asked for.
+export const DEFAULT_INHERIT_POSITION = 'always';
+export const DEFAULT_INHERIT_ROTATION = 'none';
+export const DEFAULT_INHERIT_SCALE = 'none';
+
+// What happens to a child instance's already-emitted particles when its parent
+// particle dies. `detach` lets them live out their lives (a spark's smoke should
+// outlive the spark); `kill` takes them with it.
+export const DEFAULT_ORPHAN_POLICY = 'detach';

--- a/test/core/fromJSON.spec.js
+++ b/test/core/fromJSON.spec.js
@@ -143,4 +143,71 @@ describe('fromJSON', () => {
       'The zone type MrDoob is invalid or not yet supported'
     );
   });
+
+  describe('emitter hierarchy (children)', () => {
+    const withChild = (childProps = {}) => ({
+      emitters: [
+        {
+          rate: { particlesMin: 1, particlesMax: 1 },
+          initializers: [],
+          behaviours: [],
+          children: [
+            {
+              rate: { particlesMin: 1, particlesMax: 1 },
+              initializers: [],
+              behaviours: [],
+              ...childProps,
+            },
+          ],
+        },
+      ],
+    });
+
+    it('nests child emitters as childNodes rather than top-level emitters', () => {
+      const system = Particles.fromJSON(withChild(), THREE);
+
+      assert.lengthOf(system.emitters, 1, 'child is not a sibling');
+      assert.lengthOf(system.emitters[0].childNodes, 1);
+    });
+
+    it('assigns tree-path node ids across the subtree', () => {
+      const system = Particles.fromJSON(withChild(), THREE);
+
+      assert.equal(system.emitters[0].nodeId, '0');
+      assert.equal(system.emitters[0].childNodes[0].nodeId, '0/children/0');
+    });
+
+    it('parses inherit (merged over defaults) and orphanPolicy', () => {
+      const system = Particles.fromJSON(
+        withChild({
+          inherit: { position: 'onCreate' },
+          orphanPolicy: 'kill',
+        }),
+        THREE
+      );
+      const child = system.emitters[0].childNodes[0];
+
+      assert.equal(child.inherit.position, 'onCreate', 'overridden');
+      assert.equal(child.inherit.rotation, 'none', 'default preserved');
+      assert.equal(child.orphanPolicy, 'kill');
+    });
+
+    it('defaults inherit and orphanPolicy when absent', () => {
+      const child = Particles.fromJSON(withChild(), THREE).emitters[0]
+        .childNodes[0];
+
+      assert.deepEqual(child.inherit, {
+        position: 'always',
+        rotation: 'none',
+        scale: 'none',
+      });
+      assert.equal(child.orphanPolicy, 'detach');
+    });
+
+    it('leaves flat (childless) emitters unchanged', () => {
+      const system = Particles.fromJSON(emitterWith({}), THREE);
+
+      assert.lengthOf(system.emitters[0].childNodes, 0);
+    });
+  });
 });

--- a/test/emitter/Emitter.hierarchy.spec.js
+++ b/test/emitter/Emitter.hierarchy.spec.js
@@ -1,0 +1,197 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life } = Nebula;
+
+const STEP = 1 / 60;
+
+// Builds a two-level system: a parent that bursts N particles once, each riding
+// a child emitter that continuously emits its own particles. Lifetimes are set
+// via Life initializers so parents/children die on a known schedule.
+const build = ({
+  seed = 1234,
+  parentCount = 3,
+  parentLife = 0.2,
+  childLife = 0.1,
+  orphanPolicy = 'detach',
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(seed);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(parentCount, parentCount), new Span(0.01, 0.01)))
+    .addInitializer(new Life(parentLife, parentLife));
+
+  const child = new Emitter();
+
+  child
+    .setRate(new Rate(new Span(2, 2), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife));
+  child.orphanPolicy = orphanPolicy;
+  child.emit(Infinity, Infinity);
+
+  parent.addChild(child);
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent, child };
+};
+
+// Steps the system, ignoring the returned (already-resolved) promise.
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+// Every live particle id in the system — parents, children (recursively) and
+// detached instances — for determinism/lifecycle assertions.
+const collectParticleIds = system => {
+  const ids = [];
+  const visit = emitter => {
+    emitter.particles.forEach(p => ids.push(p.id));
+    emitter.activeChildren.forEach(instances => instances.forEach(visit));
+  };
+
+  system.emitters.forEach(visit);
+  system._detached.forEach(visit);
+
+  return ids.sort();
+};
+
+describe('emitter -> Emitter -> hierarchy', () => {
+  it('instances one child emitter per parent particle at spawn', () => {
+    const { system, parent } = build({ parentCount: 4 });
+
+    step(system);
+
+    assert.lengthOf(parent.particles, 4, 'parent burst 4 particles');
+    assert.equal(
+      parent.activeChildren.size,
+      4,
+      'one child instance per parent'
+    );
+    assert.equal(system._liveEmitterInstances, 4);
+
+    parent.activeChildren.forEach((instances, particle) => {
+      assert.lengthOf(instances, 1);
+      assert.strictEqual(instances[0]._parentParticle, particle);
+      assert.strictEqual(instances[0].parent, system, 'parented to the System');
+      assert.isTrue(instances[0].isEmitting);
+    });
+  });
+
+  it("tracks the parent particle's transform (position: always)", () => {
+    const { system, parent } = build({ parentCount: 1 });
+
+    parent.setPosition({ x: 25, y: -8 });
+    step(system);
+
+    const particle = parent.particles[0];
+    const [instance] = parent.activeChildren.get(particle);
+
+    assert.closeTo(instance.position.x, particle.position.x, 1e-9);
+    assert.closeTo(instance.position.y, particle.position.y, 1e-9);
+    assert.isAbove(instance.particles.length, 0, 'child emitted particles');
+  });
+
+  it('stamps each particle with the id of the emitter that spawned it', () => {
+    const { system, parent } = build({ parentCount: 1 });
+
+    step(system);
+
+    const particle = parent.particles[0];
+    const [instance] = parent.activeChildren.get(particle);
+
+    assert.equal(particle.emitterId, '0', 'top-level node id');
+    assert.equal(instance.particles[0].emitterId, '0/children/0');
+  });
+
+  it('detaches child instances when their parent dies, draining then releasing', () => {
+    const { system, parent } = build({
+      parentCount: 2,
+      parentLife: 0.1,
+      childLife: 0.1,
+      orphanPolicy: 'detach',
+    });
+
+    step(system); // parents + children spawn
+    assert.equal(system._liveEmitterInstances, 2);
+
+    // Age past the parents' life so they die and their children detach.
+    step(system, 8);
+    assert.lengthOf(parent.particles, 0, 'parents gone');
+    assert.isAbove(system._detached.length, 0, 'children detached, not killed');
+    system._detached.forEach(inst => assert.isFalse(inst.isEmitting));
+
+    // Age past the detached children's particle life; they drain and release.
+    step(system, 12);
+    assert.lengthOf(system._detached, 0, 'detached instances drained');
+    assert.equal(system._liveEmitterInstances, 0);
+  });
+
+  it('kills child instances (and their particles) with the parent under orphanPolicy: kill', () => {
+    const { system, parent } = build({
+      parentCount: 2,
+      parentLife: 0.1,
+      childLife: 10, // long — proves kill is immediate, not lifetime-driven
+      orphanPolicy: 'kill',
+    });
+
+    step(system);
+    assert.equal(system._liveEmitterInstances, 2);
+
+    step(system, 8); // parents die
+    assert.lengthOf(parent.particles, 0);
+    assert.lengthOf(system._detached, 0, 'kill does not detach');
+    assert.equal(system._liveEmitterInstances, 0, 'instances released at once');
+  });
+
+  it('recycles child instances across parent lifecycles', () => {
+    const { system } = build({
+      parentCount: 2,
+      parentLife: 0.1,
+      childLife: 0.05,
+    });
+
+    // Run long enough for a full spawn→detach→drain→release cycle.
+    step(system, 25);
+
+    assert.isAbove(system._emitterPoolHits + system._emitterPoolMisses, 0);
+    assert.equal(system._liveEmitterInstances, 0, 'nothing leaked');
+  });
+
+  it('produces identical output for the same seed (determinism)', () => {
+    const a = build({ seed: 777 }).system;
+    const b = build({ seed: 777 }).system;
+
+    for (let i = 0; i < 10; i++) {
+      a.update(STEP);
+      b.update(STEP);
+
+      assert.deepEqual(collectParticleIds(a), collectParticleIds(b));
+    }
+  });
+
+  it('rejects a hierarchy deeper than maxEmitterDepth', () => {
+    const system = new System(); // default maxEmitterDepth = 4
+    const root = new Emitter();
+
+    let node = root;
+
+    // root (0) + 5 nested children => deepest node at depth 5 > 4.
+    for (let i = 0; i < 5; i++) {
+      const next = new Emitter();
+
+      node.addChild(next);
+      node = next;
+    }
+
+    assert.throws(() => system.addEmitter(root), /maxDepth/);
+  });
+});


### PR DESCRIPTION
Second PR in the emitter-hierarchy (spec 01) stack. **Base is the integration branch** `feat/emitter-hierarchy`, which already carries Stage 0 (audit) + Stage 1 (the emitter-instance pool). Review this on top of that.

## What this adds

Wires the emitter tree onto the Stage 1 pool: a child emitter is instanced **once per parent particle**, rides it, and is recycled when it dies.

- **Schema (additive).** `EmitterJSON` gains optional `children[]`, `inherit`, `orphanPolicy`. A childless emitter is byte-for-byte today's flat leaf. Both `fromJSON` and `fromJSONAsync` build the tree recursively; only the root is added to the System.
- **Node ids + depth guard.** `System.addEmitter` assigns tree-path ids across the subtree (`0`, `0/children/1`, …) and enforces `maxEmitterDepth` (default 4) at that single choke point. `particle.emitterId` now stamps a real id.
- **Instancing + rendering.** An emitter spawns a child instance per new particle; the instance is parented to the System so its particles flow through the same event stream as everyone else (the B1 rendering decision — no renderer changes).
- **Inheritance.** Parent transform copied per channel — `position`/`rotation` in `always` or `onCreate` mode. (`scale` and the `onCreate`→ribbon payoff are Stage 3/4.)
- **Update order** is topological: an emitter advances its own particles, then its child instances, depth-first.
- **Orphan lifecycle.** On parent death, children `detach` (keep draining their particles, then release — default) or `kill` (expire particles + descendants immediately). Detached instances drain via `System._updateDetached`.
- **Determinism.** A child instance re-seeds from `hash(nodeId, parentParticleId)` and re-draws its rate interval from that stream, so nested output is reproducible.

## Tests

- `test/emitter/Emitter.hierarchy.spec.js` — instancing, inheritance, both orphan policies, recycling, determinism, depth guard.
- `test/core/fromJSON.spec.js` — hierarchy parse (nesting, node ids, inherit merge, defaults, flat unchanged).
- Full suite: **296 pass**; `tsc` clean; lint/format/madge clean.

## Try it

`npm run sandbox` → "Emitter Hierarchy" (sparks → smoke trails; dogfoods `tick`). Mid-run stats confirm one live child instance per spark, detached smoke outliving dead sparks, and pool recycling.

## Deferred (later PRs in the stack)

Full Stage 3 inheritance (`scale`, `onCreate`), Stage 4 Ribbon/Trail renderers, Stage 5 events.