### PR TITLE
Stage 5 — event-triggered child bursts (onDeath)

### DIFF
--- a/sandbox/experiments/emitter-hierarchy/index.html
+++ b/sandbox/experiments/emitter-hierarchy/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Emitter Hierarchy — sparks leaving smoke trails</title>
+    <title>Emitter Hierarchy — healing aura</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -18,10 +18,18 @@ import System, {
 import { run } from '/common/run.js';
 
 // Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
-// outward; each spark rides a child "smoke" emitter (inherit.position: 'always',
-// orphanPolicy: 'detach') so the smoke follows its spark and lives on after the
-// spark dies. One child node → one live instance per spark, all recycled through
-// the Stage 1 pool.
+// outward; each spark rides a child "smoke" emitter (orphanPolicy: 'detach') so
+// the smoke follows its spark and lives on after the spark dies. One child node →
+// one live instance per spark, all recycled through the Stage 1 pool.
+//
+// Stage 3 inheritance modes are on show:
+//   - scale: 'always'    smoke puffs shrink as the spark shrinks
+//   - position: 'always' (default) smoke rides the spark; append
+//     ?position=onCreate to leave a stationary band where each spark was born.
+const positionMode =
+  new URLSearchParams(window.location.search).get('position') === 'onCreate'
+    ? 'onCreate'
+    : 'always';
 
 const createSprite = color => {
   const map = new THREE.TextureLoader().load('/assets/dot.png');
@@ -55,8 +63,9 @@ const createSmokeTrail = () => {
       new Color('#aaaaaa', '#222222'),
     ]);
 
-  // Follow the parent spark every frame; let emitted smoke outlive the spark.
-  smoke.inherit = { position: 'always', rotation: 'none', scale: 'none' };
+  // Track the spark's position (see positionMode) and shrink with it (scale);
+  // let emitted smoke outlive the spark.
+  smoke.inherit = { position: positionMode, rotation: 'none', scale: 'always' };
   smoke.orphanPolicy = 'detach';
   smoke.emit(Infinity, Infinity);
 

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -7,29 +7,38 @@ import System, {
   Force,
   Life,
   Mass,
+  Position,
   RadialVelocity,
   Radius,
+  RandomDrift,
   Rate,
   Scale,
+  SphereZone,
   Span,
+  VectorVelocity,
   GPURenderer,
   Vector3D,
 } from 'three-nebula';
 import { run } from '/common/run.js';
 
-// Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
-// outward; each spark rides a child "smoke" emitter (orphanPolicy: 'detach') so
-// the smoke follows its spark and lives on after the spark dies. One child node →
-// one live instance per spark, all recycled through the Stage 1 pool.
+// Healing aura — a designed showcase of the emitter hierarchy (spec 01).
 //
-// Stage 3 inheritance modes are on show:
-//   - scale: 'always'    smoke puffs shrink as the spark shrinks
-//   - position: 'always' (default) smoke rides the spark; append
-//     ?position=onCreate to leave a stationary band where each spark was born.
+// A ground cluster lifts soft green→gold "motes" (parent). Each mote rides a
+// child "sparkle" emitter that inherits its transform, so the sparkles ride the
+// mote up the column and — because scale is inherited — shrink as the mote fades.
+// orphanPolicy 'detach' lets a mote's sparkles twinkle out on their own after the
+// mote dies. One child node → one live sparkle emitter per mote, all recycled
+// through the pool.
+//
+// Append ?position=onCreate to switch the sparkles from riding the mote (a
+// trailing shimmer) to snapping to where the mote was born (a standing pillar of
+// light) — the Stage 3 always↔onCreate contrast.
 const positionMode =
   new URLSearchParams(window.location.search).get('position') === 'onCreate'
     ? 'onCreate'
     : 'always';
+
+const BASE_Y = -120;
 
 const createSprite = color => {
   const map = new THREE.TextureLoader().load('/assets/dot.png');
@@ -44,64 +53,70 @@ const createSprite = color => {
   );
 };
 
-// The child: a slow, greying puff that trails whichever spark spawned it.
-const createSmokeTrail = () => {
-  const smoke = new Emitter();
+// The child: a small, bright twinkle that rides (or is left behind by) its mote.
+const createSparkles = () => {
+  const sparkles = new Emitter();
 
-  smoke
-    .setRate(new Rate(new Span(1, 2), new Span(0.02, 0.04)))
+  sparkles
+    .setRate(new Rate(new Span(1, 2), new Span(0.03, 0.06)))
     .setInitializers([
       new Mass(1),
-      new Life(0.6, 1.1),
-      new Body(createSprite(0x888888)),
-      new Radius(16, 32),
-      new RadialVelocity(15, new Vector3D(0, 1, 0), 30),
-    ])
-    .setBehaviours([
-      new Alpha(0.35, 0),
-      new Scale(0.5, 1.6),
-      new Color('#aaaaaa', '#222222'),
-    ]);
-
-  // Track the spark's position (see positionMode) and shrink with it (scale);
-  // let emitted smoke outlive the spark.
-  smoke.inherit = { position: positionMode, rotation: 'none', scale: 'always' };
-  smoke.orphanPolicy = 'detach';
-  smoke.emit(Infinity, Infinity);
-
-  return smoke;
-};
-
-// The parent: bright, fast sparks under gravity, each carrying a smoke child.
-const createSparks = () => {
-  const sparks = new Emitter();
-
-  sparks
-    .setRate(new Rate(new Span(2, 4), new Span(0.06, 0.1)))
-    .setInitializers([
-      new Mass(1),
-      new Life(1.1, 1.7),
-      new Body(createSprite(0xffcc33)),
-      new Radius(26, 46),
-      new RadialVelocity(220, new Vector3D(0, 1, 0), 55),
+      new Life(0.35, 0.7),
+      new Body(createSprite(0xffffff)),
+      new Radius(3, 6),
+      new RadialVelocity(16, new Vector3D(0, 1, 0), 70),
     ])
     .setBehaviours([
       new Alpha(1, 0),
-      new Scale(1, 0.25),
-      new Color('#fffb00', '#ff3c00'),
-      new Force(0, -140, 0),
+      new Color('#ffffff', '#ffd86b'),
+      new Scale(1, 0.1),
     ]);
 
-  sparks.addChild(createSmokeTrail());
+  // Ride the mote (position) and shrink with it (scale); linger after it dies.
+  sparkles.inherit = {
+    position: positionMode,
+    rotation: 'none',
+    scale: 'always',
+  };
+  sparkles.orphanPolicy = 'detach';
+  sparkles.emit(Infinity, Infinity);
 
-  return sparks.emit();
+  return sparkles;
+};
+
+// The parent: soft motes rising from a base cluster, greening into gold.
+const createMotes = () => {
+  const motes = new Emitter();
+
+  motes
+    .setRate(new Rate(new Span(3, 5), new Span(0.02, 0.04)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1.6, 2.6),
+      new Body(createSprite(0xffffff)),
+      new Radius(8, 16),
+      new Position(new SphereZone(45)),
+      new VectorVelocity(new Vector3D(0, 90, 0), 25),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Color('#7cffb0', '#ffe68a'),
+      new Scale(0.7, 1.5),
+      new RandomDrift(18, 8, 18, 0.1),
+      new Force(0, 30, 0),
+    ]);
+
+  motes.setPosition({ x: 0, y: BASE_Y, z: 0 });
+  motes.addChild(createSparkles());
+
+  return motes.emit();
 };
 
 const init = async ({ scene }) => {
   const system = new System();
 
   return system
-    .addEmitter(createSparks())
+    .addEmitter(createMotes())
     .addRenderer(new GPURenderer(scene, THREE));
 };
 

--- a/sandbox/experiments/fireworks/index.html
+++ b/sandbox/experiments/fireworks/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Emitter Events — fireworks (burst on death)</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/fireworks/index.js
+++ b/sandbox/experiments/fireworks/index.js
@@ -1,0 +1,117 @@
+import * as THREE from 'three';
+import System, {
+  Alpha,
+  Body,
+  Color,
+  Emitter,
+  Force,
+  Life,
+  Mass,
+  RadialVelocity,
+  Radius,
+  Rate,
+  Scale,
+  Span,
+  GPURenderer,
+  Vector3D,
+} from 'three-nebula';
+import { run } from '/common/run.js';
+
+// Emitter events (spec 01, Stage 5). Each rocket is a parent emitter whose
+// particles rise and die mid-air; a `trigger: 'death'` child bursts a shell of
+// sparks at the death position and outlives the rocket. Unlike attachment
+// (Stages 2–3), the burst is instanced *at death*, not birth. One GPURenderer
+// draws rockets and sparks alike (points), so no per-emitter routing is needed.
+
+const PALETTE = [
+  ['#fff6a0', '#ff5a3c'], // gold → red
+  ['#a0f0ff', '#2a6cff'], // cyan → blue
+  ['#ffc0f0', '#c030ff'], // pink → purple
+];
+
+const UP = new Vector3D(0, 1, 0);
+const BASE_Y = -150;
+
+const createSprite = () => {
+  const map = new THREE.TextureLoader().load('/assets/dot.png');
+
+  return new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map,
+      color: 0xffffff,
+      blending: THREE.AdditiveBlending,
+      fog: true,
+    })
+  );
+};
+
+// The shell: a one-shot radial burst that fires when its rocket dies.
+const createBurst = ([colorA, colorB]) => {
+  const burst = new Emitter();
+
+  burst
+    .setRate(new Rate(new Span(60, 90), new Span(0.01, 0.01)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1, 1.7),
+      new Body(createSprite()),
+      new Radius(6, 12),
+      new RadialVelocity(new Span(130, 230), UP, 180), // omnidirectional
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Color(colorA, colorB),
+      new Scale(1, 0.3),
+      // Force is scaled ×100 internally (MEASURE), so this is ~100 units/s² down.
+      new Force(0, -1, 0),
+    ]);
+
+  burst.trigger = 'death'; // instanced at the rocket's death, not its birth
+  burst.emit(1); // one-shot
+
+  return burst;
+};
+
+// The rocket: rises from the base, arcs under gravity, dies mid-air.
+const createRocket = (palette, x) => {
+  const rocket = new Emitter();
+
+  rocket
+    .setRate(new Rate(new Span(1, 1), new Span(0.7, 1.1)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1, 1.4),
+      new Body(createSprite()),
+      new Radius(7, 11),
+      new RadialVelocity(300, UP, 18),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0.7),
+      new Color('#ffffff', palette[0]),
+      new Scale(1, 0.6),
+      // ~160 units/s² down (×100 MEASURE); rocket dies while still rising.
+      new Force(0, -1.6, 0),
+    ]);
+
+  rocket.setPosition({ x, y: BASE_Y });
+  rocket.addChild(createBurst(palette));
+
+  return rocket.emit();
+};
+
+const init = async ({ scene, camera }) => {
+  const system = new System();
+  const spread = [-150, 0, 150];
+
+  PALETTE.forEach((palette, i) =>
+    system.addEmitter(createRocket(palette, spread[i]))
+  );
+  system.addRenderer(new GPURenderer(scene, THREE));
+
+  camera.position.set(0, 20, 560);
+  camera.lookAt(0, 20, 0);
+
+  return system;
+};
+
+run(init, { shouldRotateCamera: false, shouldAddCameraControls: true });

--- a/sandbox/experiments/ribbon-trails/index.html
+++ b/sandbox/experiments/ribbon-trails/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Ribbon Renderer — flowing trails</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/ribbon-trails/index.js
+++ b/sandbox/experiments/ribbon-trails/index.js
@@ -1,0 +1,81 @@
+import * as THREE from 'three';
+import System, {
+  Alpha,
+  Color,
+  Emitter,
+  Life,
+  Mass,
+  Rate,
+  Scale,
+  Span,
+  RibbonRenderer,
+} from 'three-nebula';
+import { run } from '/common/run.js';
+
+// Ribbon renderer (spec 01, Stage 4). Each emitter lays a dense, stationary
+// stream of short-lived particles as it flies along a path; the RibbonRenderer
+// connects each emitter's particles (its spine, in spawn order) into one
+// continuous, camera-facing strip. Several emitters → several ribbons, keyed by
+// emitterInstanceId — the per-instance grouping the hierarchy relies on.
+
+const PALETTE = [
+  ['#00ffa3', '#0066ff'],
+  ['#ff4d6d', '#ffd166'],
+  ['#8a5cff', '#00e5ff'],
+];
+
+// A ribbon emitter emits a fast, dense stream of near-stationary particles (so
+// they stay on the path) that fade and taper (Scale → 0) toward the tail.
+const createRibbonEmitter = ([colorA, colorB]) => {
+  const emitter = new Emitter();
+
+  return emitter
+    .setRate(new Rate(new Span(2, 3), new Span(0.006, 0.012)))
+    .setInitializers([new Mass(1), new Life(0.9, 1.3)])
+    .setBehaviours([
+      new Color(colorA, colorB),
+      new Scale(1, 0),
+      new Alpha(1, 0),
+    ])
+    .emit();
+};
+
+// Fly each emitter along a phase-shifted Lissajous path; particles are left
+// behind on the path, so the ribbon traces where the emitter has been.
+const fly = (emitters, t = 0) => {
+  t += 0.016;
+
+  emitters.forEach((emitter, i) => {
+    const phase = (i / emitters.length) * Math.PI * 2;
+    const r = 120;
+
+    emitter.position.x = r * Math.cos(t * 1.1 + phase);
+    emitter.position.y = r * 0.6 * Math.sin(t * 1.7 + phase);
+    emitter.position.z = r * 0.45 * Math.sin(t * 0.9 + phase);
+  });
+
+  requestAnimationFrame(() => fly(emitters, t));
+};
+
+const init = async ({ scene, camera }) => {
+  const system = new System();
+  const emitters = PALETTE.map(createRibbonEmitter);
+  const renderer = new RibbonRenderer(scene, THREE, {
+    camera,
+    width: 16,
+    blending: 'AdditiveBlending',
+    uv: 'stretch',
+  });
+
+  // Pull back so the whole ±120 path is framed.
+  camera.position.set(0, 0, 440);
+  camera.lookAt(0, 0, 0);
+
+  emitters.forEach(emitter => system.addEmitter(emitter));
+  system.addRenderer(renderer);
+  fly(emitters);
+
+  return system;
+};
+
+run(init, { shouldRotateCamera: false, shouldAddCameraControls: true });

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,8 +12,8 @@
       <ul>
         <li>
           <a href="experiments/emitter-hierarchy/index.html">
-            Emitter Hierarchy — sparks leaving smoke trails (child emitters) —
-            add ?position=onCreate for left-behind bands
+            Emitter Hierarchy — healing aura (motes each trailing a sparkle
+            child) — add ?position=onCreate for a standing pillar
           </a>
         </li>
         <li>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -22,6 +22,11 @@
           </a>
         </li>
         <li>
+          <a href="experiments/fireworks/index.html">
+            Emitter Events — fireworks (rockets burst on death)
+          </a>
+        </li>
+        <li>
           <a href="experiments/determinism/index.html">
             Determinism — same seed, same result (toggle "desync" to diverge)
           </a>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -17,6 +17,11 @@
           </a>
         </li>
         <li>
+          <a href="experiments/ribbon-trails/index.html">
+            Ribbon Renderer — flowing camera-facing trails (one strip per emitter)
+          </a>
+        </li>
+        <li>
           <a href="experiments/determinism/index.html">
             Determinism — same seed, same result (toggle "desync" to diverge)
           </a>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,7 +12,8 @@
       <ul>
         <li>
           <a href="experiments/emitter-hierarchy/index.html">
-            Emitter Hierarchy — sparks leaving smoke trails (child emitters)
+            Emitter Hierarchy — sparks leaving smoke trails (child emitters) —
+            add ?position=onCreate for left-behind bands
           </a>
         </li>
         <li>

--- a/src/core/Particle.ts
+++ b/src/core/Particle.ts
@@ -65,11 +65,17 @@ export default class Particle {
   hasBeenInitialized?: boolean;
   // Set by Emitter.setupParticle — the particle's index within its emitter.
   index?: number;
-  // Emitter hierarchy (spec 01): the tree-path id of the emitter that spawned
-  // this particle (null for top-level emitters). Stamped in Emitter.setupParticle
-  // and, like `id`, deliberately preserved across pooling until the next setup
-  // overwrites it. Renderers/ribbon grouping key off this without re-hashing.
+  // Emitter hierarchy (spec 01): the tree-path id of the emitter *definition*
+  // that spawned this particle (null for a flat top-level emitter). Shared by all
+  // instances of one node — the "which kind of thing" key (look/config).
   emitterId: string | null;
+  // The specific emitting *instance* (spec 01, Stage 4): the emitter's seed as a
+  // string. Unique per live emitter — every instance of a child node has its own —
+  // so the RibbonRenderer groups particles into one strip per trail. `spawnIndex`
+  // is the monotonic order within that instance, giving the strip its spine order.
+  // Both are stamped in setupParticle and preserved across pooling like `id`.
+  emitterInstanceId: string | null;
+  spawnIndex: number;
   // The particle's own seeded PRNG stream (Stage 2). Assigned by
   // Emitter.setupParticle from the emitter seed + a monotonic spawn index, so a
   // particle's randomness is a pure function of who spawned it and when.
@@ -87,6 +93,8 @@ export default class Particle {
   constructor(properties: Record<string, unknown> = {}) {
     this.id = `particle-${uid()}`;
     this.emitterId = null;
+    this.emitterInstanceId = null;
+    this.spawnIndex = 0;
     this.type = type;
     this.life = DEFAULT_LIFE;
     this.age = DEFAULT_AGE;

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -150,12 +150,18 @@ export default class System {
   }
 
   /**
-   * Detaches a child instance from its dead parent: it stops emitting but keeps
-   * updating so its already-emitted particles live out their lives, then is
-   * released once drained (see `_updateDetached`). This is the `detach` policy.
+   * Detaches a child instance from its (dead or absent) parent: it keeps updating
+   * so its already-emitted particles live out their lives, then is released once
+   * drained (see `_updateDetached`). Used by the `detach` orphan policy
+   * (`stopEmitting` true) and by `death`-trigger event bursts, which stay
+   * emitting so their one-shot burst fires after detachment (`stopEmitting`
+   * false — their own totalEmitTimes/life then bounds emission).
    */
-  _detachInstance(inst: Emitter): void {
-    inst.isEmitting = false;
+  _detachInstance(inst: Emitter, stopEmitting = true): void {
+    if (stopEmitting) {
+      inst.isEmitting = false;
+    }
+
     inst._parentParticle = null;
     this._detached.push(inst);
   }

--- a/src/core/fromJSON.ts
+++ b/src/core/fromJSON.ts
@@ -17,7 +17,11 @@ import type {
 import Rate from '../initializer/Rate';
 import type System from './System';
 import type Emitter from '../emitter/Emitter';
-import type { InheritConfig, OrphanPolicy } from '../emitter/Emitter';
+import type {
+  InheritConfig,
+  OrphanPolicy,
+  EmitterTrigger,
+} from '../emitter/Emitter';
 import type InitializerBase from '../initializer/Initializer';
 import type BehaviourBase from '../behaviour/Behaviour';
 
@@ -108,6 +112,9 @@ export interface EmitterJSON {
   children?: EmitterJSON[];
   inherit?: Partial<InheritConfig>;
   orphanPolicy?: OrphanPolicy;
+  // Stage 5: `spawn` (default) attaches this child at parent birth; `death`
+  // bursts it at parent death.
+  trigger?: EmitterTrigger;
 }
 
 export interface SystemJSON {
@@ -205,6 +212,7 @@ const buildEmitter = (
     children = [],
     inherit,
     orphanPolicy,
+    trigger,
   } = data;
 
   emitter.damping = damping;
@@ -223,6 +231,10 @@ const buildEmitter = (
 
   if (orphanPolicy) {
     emitter.orphanPolicy = orphanPolicy;
+  }
+
+  if (trigger) {
+    emitter.trigger = trigger;
   }
 
   children.forEach(child =>

--- a/src/core/fromJSONAsync.ts
+++ b/src/core/fromJSONAsync.ts
@@ -161,6 +161,7 @@ const buildEmitterAsync = (
     children = [],
     inherit,
     orphanPolicy,
+    trigger,
   } = data;
 
   emitter.damping = damping;
@@ -172,6 +173,10 @@ const buildEmitterAsync = (
 
   if (orphanPolicy) {
     emitter.orphanPolicy = orphanPolicy;
+  }
+
+  if (trigger) {
+    emitter.trigger = trigger;
   }
 
   return makeInitializers(initializers, THREE)

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -52,11 +52,20 @@ export interface InheritConfig {
 /** What becomes of a dead parent's already-emitted child particles. */
 export type OrphanPolicy = 'kill' | 'detach';
 
+/** True when a channel should be applied on this call (Stage 3). */
+const shouldInherit = (mode: InheritMode, atSpawn: boolean): boolean =>
+  mode === 'always' || (atSpawn && mode === 'onCreate');
+
 /**
- * Copies the parent particle's transform onto a child instance according to its
- * `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
- * per-frame call (atSpawn=false) only re-applies the continuous `always` mode.
- * Scale inheritance is deferred to Stage 3 (it needs a per-emitter scale offset).
+ * Reflects the parent particle's transform onto a child instance according to
+ * its `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
+ * per-frame call (atSpawn=false) only re-applies continuous `always` channels.
+ *
+ * Position and rotation copy directly onto the instance (which bindEmitter then
+ * adds to each emitted particle). Scale can't do the same — a Scale behaviour
+ * overwrites `particle.scale` every frame — so the parent's scale is captured
+ * here and baked into each child particle's `radius` at birth (see setupParticle),
+ * which behaviours leave alone.
  */
 const applyInheritance = (
   inst: Emitter,
@@ -65,18 +74,16 @@ const applyInheritance = (
 ): void => {
   const { inherit } = inst;
 
-  if (
-    inherit.position === 'always' ||
-    (atSpawn && inherit.position === 'onCreate')
-  ) {
+  if (shouldInherit(inherit.position, atSpawn)) {
     inst.position.copy(particle.position);
   }
 
-  if (
-    inherit.rotation === 'always' ||
-    (atSpawn && inherit.rotation === 'onCreate')
-  ) {
+  if (shouldInherit(inherit.rotation, atSpawn)) {
     inst.rotation.copy(particle.rotation);
+  }
+
+  if (shouldInherit(inherit.scale, atSpawn)) {
+    inst._inheritedScale = particle.scale;
   }
 };
 
@@ -120,6 +127,9 @@ export default class Emitter extends Particle {
   orphanPolicy: OrphanPolicy;
   _template: Emitter | null;
   _parentParticle: Particle | null;
+  // The parent particle's scale captured for `inherit.scale`, baked into each
+  // child particle's radius at birth. 1 when scale is not inherited.
+  _inheritedScale: number;
   _freeInstances: Emitter[];
   // Live child instances riding each of this emitter's still-alive particles,
   // keyed by the parent particle so they can be orphaned when it dies. On a live
@@ -143,6 +153,7 @@ export default class Emitter extends Particle {
     this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
     this._template = null;
     this._parentParticle = null;
+    this._inheritedScale = 1;
     this._freeInstances = [];
     this.activeChildren = new Map();
     this.particles = [];
@@ -245,6 +256,7 @@ export default class Emitter extends Particle {
     this.particles.length = 0;
     this.activeChildren.clear();
     this._parentParticle = null;
+    this._inheritedScale = 1;
     this.position.set(0, 0, 0);
     this.rotation.clear();
   }
@@ -742,6 +754,12 @@ export default class Emitter extends Particle {
     particle.emitterId = this.nodeId || null;
 
     InitializerUtil.initialize(this, particle, initializers);
+
+    // Bake inherited parent scale into radius (Scale behaviours overwrite
+    // `scale` each frame; radius they leave alone). 1 for non-inheriting emitters.
+    if (this._inheritedScale !== 1) {
+      particle.radius *= this._inheritedScale;
+    }
 
     particle.addBehaviours(behaviours);
     particle.parent = this;

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_INHERIT_ROTATION,
   DEFAULT_INHERIT_SCALE,
   DEFAULT_ORPHAN_POLICY,
+  DEFAULT_EMITTER_TRIGGER,
 } from './constants';
 import { DEFAULT_MAX_DEPTH } from '../core/constants';
 import EventDispatcher, {
@@ -51,6 +52,14 @@ export interface InheritConfig {
 
 /** What becomes of a dead parent's already-emitted child particles. */
 export type OrphanPolicy = 'kill' | 'detach';
+
+/**
+ * When a child emitter is instanced (spec 01, Stage 5). `spawn` is attachment —
+ * instanced at the parent particle's birth and riding it. `death` is an event —
+ * instanced at the parent particle's death, bursting once at that position and
+ * outliving the parent (fireworks). `collision` is reserved for later.
+ */
+export type EmitterTrigger = 'spawn' | 'death';
 
 /** True when a channel should be applied on this call (Stage 3). */
 const shouldInherit = (mode: InheritMode, atSpawn: boolean): boolean =>
@@ -125,6 +134,9 @@ export default class Emitter extends Particle {
   childNodes: Emitter[];
   inherit: InheritConfig;
   orphanPolicy: OrphanPolicy;
+  // Whether this (child) node is attached at parent birth (`spawn`) or burst at
+  // parent death (`death`). Meaningless on a top-level emitter.
+  trigger: EmitterTrigger;
   _template: Emitter | null;
   _parentParticle: Particle | null;
   // The parent particle's scale captured for `inherit.scale`, baked into each
@@ -151,6 +163,7 @@ export default class Emitter extends Particle {
       scale: DEFAULT_INHERIT_SCALE,
     };
     this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
+    this.trigger = DEFAULT_EMITTER_TRIGGER;
     this._template = null;
     this._parentParticle = null;
     this._inheritedScale = 1;
@@ -227,6 +240,7 @@ export default class Emitter extends Particle {
     inst.childNodes = this.childNodes;
     inst.inherit = this.inherit;
     inst.orphanPolicy = this.orphanPolicy;
+    inst.trigger = this.trigger;
     inst.damping = this.damping;
     inst.rate = new Rate(this.rate.numPan, this.rate.timePan);
     inst.totalEmitTimes = this.totalEmitTimes;
@@ -344,7 +358,15 @@ export default class Emitter extends Particle {
     const instances: Emitter[] = [];
 
     for (let i = 0; i < this.childNodes.length; i++) {
-      const inst = system.spawnEmitterInstance(this.childNodes[i], particle);
+      const node = this.childNodes[i];
+
+      // Only `spawn`-trigger children attach at birth; `death` children are held
+      // back and burst when the parent particle dies (see _triggerDeathChildren).
+      if (node.trigger !== 'spawn') {
+        continue;
+      }
+
+      const inst = system.spawnEmitterInstance(node, particle);
 
       if (!inst) {
         continue;
@@ -356,6 +378,35 @@ export default class Emitter extends Particle {
 
     if (instances.length) {
       this.activeChildren.set(particle, instances);
+    }
+  }
+
+  /**
+   * Bursts every `death`-trigger child node at a particle that has just died: the
+   * instance is placed at the death position and released as a free-running,
+   * still-emitting detached instance, so its one-shot burst outlives the parent.
+   * Runs before the particle is reset (its position is still valid).
+   */
+  _triggerDeathChildren(particle: Particle): void {
+    const system = this.system as System;
+
+    for (let i = 0; i < this.childNodes.length; i++) {
+      const node = this.childNodes[i];
+
+      if (node.trigger !== 'death') {
+        continue;
+      }
+
+      const inst = system.spawnEmitterInstance(node, particle);
+
+      if (!inst) {
+        continue;
+      }
+
+      // Snapshot the death location; there is no parent to ride. Detach while
+      // keeping it emitting so its burst fires, then it drains and releases.
+      inst.position.copy(particle.position);
+      system._detachInstance(inst, false);
     }
   }
 
@@ -799,8 +850,12 @@ export default class Emitter extends Particle {
       const particle = this.particles[i];
 
       if (particle.dead) {
-        // Detach or kill any child instances riding this particle before it is
-        // reset and returned to the pool (the map is keyed on the particle).
+        // Before the particle is reset (its position is still valid): burst any
+        // `death`-trigger children at the death spot, then detach/kill any
+        // `spawn` children riding it (the map is keyed on the particle).
+        if (this.childNodes.length) {
+          this._triggerDeathChildren(particle);
+        }
         if (this.activeChildren.size) {
           this._orphanChildrenOf(particle);
         }

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -752,6 +752,10 @@ export default class Emitter extends Particle {
     // whose nodeId is still ''); lights up automatically once hierarchy loading
     // assigns tree-path ids.
     particle.emitterId = this.nodeId || null;
+    // Per-instance grouping key + spine order for the RibbonRenderer (Stage 4).
+    // The seed is unique per live emitter, so each child trail is its own strip.
+    particle.emitterInstanceId = `${this.seed}`;
+    particle.spawnIndex = spawnIndex;
 
     InitializerUtil.initialize(this, particle, initializers);
 

--- a/src/emitter/constants.ts
+++ b/src/emitter/constants.ts
@@ -17,3 +17,9 @@ export const DEFAULT_INHERIT_SCALE = 'none';
 // particle dies. `detach` lets them live out their lives (a spark's smoke should
 // outlive the spark); `kill` takes them with it.
 export const DEFAULT_ORPHAN_POLICY = 'detach';
+
+// When a child emitter is instanced (spec 01, Stage 5). `spawn` (default) is
+// attachment — instanced at parent-particle birth, rides it (Stages 2–3).
+// `death` is an event — instanced at parent-particle death, bursts at the death
+// position and outlives the parent (fireworks).
+export const DEFAULT_EMITTER_TRIGGER = 'spawn';

--- a/src/renderer/RibbonRenderer.ts
+++ b/src/renderer/RibbonRenderer.ts
@@ -1,0 +1,364 @@
+import BaseRenderer from './BaseRenderer';
+import { RENDERER_TYPE_RIBBON as type } from './types';
+import type Particle from '../core/Particle';
+import type System from '../core/System';
+import type {
+  BufferGeometry,
+  Camera,
+  Mesh,
+  Object3D,
+  Texture,
+  Vector3,
+} from 'three';
+
+type ThreeApi = typeof import('three');
+
+type BlendingMode =
+  | 'AdditiveBlending'
+  | 'NormalBlending'
+  | 'NoBlending'
+  | 'SubtractiveBlending'
+  | 'MultiplyBlending';
+
+interface RibbonRendererOptions {
+  // The camera the ribbons should face. Without it, ribbons orient against a
+  // fixed world-up instead (fine for a mostly side-on view).
+  camera?: Camera;
+  // Full ribbon width in world units, multiplied per-spine-point by the
+  // particle's scale so a Scale behaviour tapers the strip.
+  width: number;
+  blending: BlendingMode;
+  // Optional strip texture. UVs run along the ribbon per `uv` mode.
+  texture?: Texture;
+  // 'stretch' maps U 0→1 across the whole ribbon; 'tile' repeats U per segment.
+  uv: 'stretch' | 'tile';
+  depthTest: boolean;
+  depthWrite: boolean;
+}
+
+const DEFAULT_OPTIONS: RibbonRendererOptions = {
+  width: 20,
+  blending: 'AdditiveBlending',
+  uv: 'stretch',
+  depthTest: true,
+  depthWrite: false,
+};
+
+// Spine order within one instance is spawn order — the strip runs oldest→newest.
+export const bySpawnIndex = (a: Particle, b: Particle): number =>
+  a.spawnIndex - b.spawnIndex;
+
+/**
+ * Triangle indices for a ribbon of `pointCount` spine points. Each point owns two
+ * vertices (left = 2i, right = 2i+1); each segment is two triangles. Pure so it
+ * can be unit tested without THREE.
+ */
+export const ribbonIndices = (pointCount: number): number[] => {
+  const indices: number[] = [];
+
+  for (let i = 0; i < pointCount - 1; i++) {
+    const l0 = 2 * i;
+    const r0 = 2 * i + 1;
+    const l1 = 2 * i + 2;
+    const r1 = 2 * i + 3;
+
+    indices.push(l0, l1, r0, r0, l1, r1);
+  }
+
+  return indices;
+};
+
+interface Ribbon {
+  mesh: Mesh;
+  geometry: BufferGeometry;
+  positions: Float32Array;
+  colors: Float32Array;
+  uvs: Float32Array;
+  capacity: number; // spine points the buffers can hold
+}
+
+/**
+ * Renders each emitter instance's particles as a single continuous, camera-facing
+ * strip — the particles are the spine, in spawn order (spec 01, Stage 4). One
+ * strip per `emitterInstanceId`, so every child-emitter trail is its own ribbon.
+ *
+ * Rebuilt each `onSystemUpdate` from the live particles the renderer is tracking;
+ * width tapers with particle scale, colour/alpha come from the particle. Handles
+ * the degenerate cases: a group of fewer than two points is hidden, and
+ * zero-length segments reuse the previous orientation rather than emit NaNs.
+ */
+export default class RibbonRenderer extends BaseRenderer {
+  three: ThreeApi;
+  container: Object3D;
+  options: RibbonRendererOptions;
+  // Live particles grouped by the instance that emitted them.
+  _groups: Map<string, Particle[]>;
+  _ribbons: Map<string, Ribbon>;
+  // Reused scratch vectors so the per-frame rebuild allocates nothing.
+  _camPos: Vector3;
+  _prev: Vector3;
+  _next: Vector3;
+  _tangent: Vector3;
+  _view: Vector3;
+  _side: Vector3;
+  _lastSide: Vector3;
+  _up: Vector3;
+
+  constructor(
+    container: Object3D,
+    THREE: ThreeApi,
+    options: Partial<RibbonRendererOptions> = {}
+  ) {
+    super(type);
+
+    this.three = THREE;
+    this.container = container;
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this._groups = new Map();
+    this._ribbons = new Map();
+    this._camPos = new THREE.Vector3();
+    this._prev = new THREE.Vector3();
+    this._next = new THREE.Vector3();
+    this._tangent = new THREE.Vector3();
+    this._view = new THREE.Vector3();
+    this._side = new THREE.Vector3();
+    this._lastSide = new THREE.Vector3(1, 0, 0);
+    this._up = new THREE.Vector3(0, 1, 0);
+  }
+
+  // Group key: the emitting instance, falling back to the node id or a shared
+  // bucket so the renderer also works on a plain (non-hierarchy) emitter.
+  _keyOf(particle: Particle): string {
+    return particle.emitterInstanceId || particle.emitterId || 'ribbon';
+  }
+
+  onParticleCreated(particle: Particle): void {
+    const key = this._keyOf(particle);
+    const group = this._groups.get(key);
+
+    if (group) {
+      group.push(particle);
+    } else {
+      this._groups.set(key, [particle]);
+    }
+  }
+
+  onParticleUpdate(): void {
+    // Positions are read from the live particles at rebuild time; nothing to do.
+  }
+
+  onParticleDead(particle: Particle): void {
+    const key = this._keyOf(particle);
+    const group = this._groups.get(key);
+
+    if (!group) {
+      return;
+    }
+
+    const index = group.indexOf(particle);
+
+    if (index > -1) {
+      group.splice(index, 1);
+    }
+
+    if (group.length === 0) {
+      this._groups.delete(key);
+      this._disposeRibbon(key);
+    }
+  }
+
+  onSystemUpdate(): void {
+    this._groups.forEach((group, key) => this._rebuild(key, group));
+  }
+
+  _rebuild(key: string, group: Particle[]): void {
+    const ribbon = this._ensureRibbon(key, group.length);
+
+    if (group.length < 2) {
+      ribbon.mesh.visible = false;
+
+      return;
+    }
+
+    ribbon.mesh.visible = true;
+    group.sort(bySpawnIndex);
+
+    const { width, uv, camera } = this.options;
+    const n = group.length;
+    const { positions, colors, uvs } = ribbon;
+
+    if (camera) {
+      camera.getWorldPosition(this._camPos);
+    }
+
+    for (let i = 0; i < n; i++) {
+      const particle = group[i];
+      const point = particle.position as unknown as Vector3;
+
+      // Tangent by central difference (forward/backward at the ends).
+      this._prev.copy(
+        i > 0 ? (group[i - 1].position as unknown as Vector3) : point
+      );
+      this._next.copy(
+        i < n - 1 ? (group[i + 1].position as unknown as Vector3) : point
+      );
+      this._tangent.subVectors(this._next, this._prev);
+
+      // Side = tangent × view, camera-facing when a camera is set.
+      if (camera) {
+        this._view.subVectors(this._camPos, point).normalize();
+      } else {
+        this._view.copy(this._up);
+      }
+
+      this._side.crossVectors(this._tangent, this._view);
+
+      if (this._side.lengthSq() < 1e-12) {
+        // Coincident points or tangent parallel to view — keep the last good
+        // orientation instead of emitting a zero-length (NaN-normal) segment.
+        this._side.copy(this._lastSide);
+      } else {
+        this._side.normalize();
+
+        // Keep the strip from flipping its edges (a bowtie/twist) where the
+        // cross product changes sign as the spine curves relative to the camera:
+        // align each side with the previous one. `_lastSide` is re-established at
+        // point 0 of every rebuild, so continuity is per-spine, not cross-frame.
+        if (i > 0 && this._side.dot(this._lastSide) < 0) {
+          this._side.negate();
+        }
+      }
+
+      this._lastSide.copy(this._side);
+
+      const half = 0.5 * width * particle.scale;
+      const lx = point.x + this._side.x * half;
+      const ly = point.y + this._side.y * half;
+      const lz = point.z + this._side.z * half;
+      const rx = point.x - this._side.x * half;
+      const ry = point.y - this._side.y * half;
+      const rz = point.z - this._side.z * half;
+
+      const vl = i * 6;
+
+      positions[vl] = lx;
+      positions[vl + 1] = ly;
+      positions[vl + 2] = lz;
+      positions[vl + 3] = rx;
+      positions[vl + 4] = ry;
+      positions[vl + 5] = rz;
+
+      const { r, g, b } = particle.color;
+      const a = particle.alpha;
+      const cl = i * 8;
+
+      colors[cl] = r;
+      colors[cl + 1] = g;
+      colors[cl + 2] = b;
+      colors[cl + 3] = a;
+      colors[cl + 4] = r;
+      colors[cl + 5] = g;
+      colors[cl + 6] = b;
+      colors[cl + 7] = a;
+
+      const u = uv === 'tile' ? i : i / (n - 1);
+      const ul = i * 4;
+
+      uvs[ul] = u;
+      uvs[ul + 1] = 1;
+      uvs[ul + 2] = u;
+      uvs[ul + 3] = 0;
+    }
+
+    const { geometry } = ribbon;
+
+    (geometry.attributes.position.array as Float32Array).set(
+      positions.subarray(0, n * 6)
+    );
+    (geometry.attributes.color.array as Float32Array).set(
+      colors.subarray(0, n * 8)
+    );
+    (geometry.attributes.uv.array as Float32Array).set(uvs.subarray(0, n * 4));
+
+    geometry.attributes.position.needsUpdate = true;
+    geometry.attributes.color.needsUpdate = true;
+    geometry.attributes.uv.needsUpdate = true;
+    geometry.setDrawRange(0, (n - 1) * 6);
+  }
+
+  // Returns the ribbon for `key`, (re)allocating its buffers to hold at least
+  // `points` spine points. Grows only — buffers are never shrunk.
+  _ensureRibbon(key: string, points: number): Ribbon {
+    const THREE = this.three;
+    let ribbon = this._ribbons.get(key);
+    const capacity = Math.max(points, 2);
+
+    if (ribbon && ribbon.capacity >= capacity) {
+      return ribbon;
+    }
+
+    // (Re)allocate buffers sized to the new capacity, preserving the mesh.
+    const positions = new Float32Array(capacity * 6);
+    const colors = new Float32Array(capacity * 8);
+    const uvs = new Float32Array(capacity * 4);
+    const indices = ribbonIndices(capacity);
+
+    let geometry: BufferGeometry;
+    let mesh: Mesh;
+
+    if (ribbon) {
+      geometry = ribbon.geometry;
+      mesh = ribbon.mesh;
+    } else {
+      geometry = new THREE.BufferGeometry();
+      const { blending, texture, depthTest, depthWrite } = this.options;
+      const material = new THREE.MeshBasicMaterial({
+        vertexColors: true,
+        transparent: true,
+        side: THREE.DoubleSide,
+        blending: THREE[blending],
+        map: texture || null,
+        depthTest,
+        depthWrite,
+      });
+
+      mesh = new THREE.Mesh(geometry, material);
+      mesh.frustumCulled = false;
+      this.container.add(mesh);
+    }
+
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 4));
+    geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+    geometry.setIndex(indices);
+
+    ribbon = { mesh, geometry, positions, colors, uvs, capacity };
+    this._ribbons.set(key, ribbon);
+
+    return ribbon;
+  }
+
+  _disposeRibbon(key: string): void {
+    const ribbon = this._ribbons.get(key);
+
+    if (!ribbon) {
+      return;
+    }
+
+    this.container.remove(ribbon.mesh);
+    ribbon.geometry.dispose();
+    (ribbon.mesh.material as { dispose: () => void }).dispose();
+    this._ribbons.delete(key);
+  }
+
+  onSystemUpdateAfter?(): void {}
+
+  remove(_system?: System): void {
+    this._ribbons.forEach((_ribbon, key) => this._disposeRibbon(key));
+    this._groups.clear();
+  }
+
+  destroy(): void {
+    this.remove();
+  }
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,5 @@
 export { default as CustomRenderer } from './CustomRenderer';
 export { default as MeshRenderer } from './MeshRenderer';
+export { default as RibbonRenderer } from './RibbonRenderer';
 export { default as SpriteRenderer } from './SpriteRenderer';
 export { default as GPURenderer } from './GPURenderer';

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -2,6 +2,7 @@ export const RENDERER_TYPE_BASE = 'BaseRenderer';
 export const RENDERER_TYPE_CUSTOM = 'CustomRenderer';
 export const RENDERER_TYPE_SPRITE = 'SpriteRenderer';
 export const RENDERER_TYPE_MESH = 'MeshRenderer';
+export const RENDERER_TYPE_RIBBON = 'RibbonRenderer';
 export const RENDERER_TYPE_GPU = 'GPURenderer';
 export const RENDERER_TYPE_GPU_MOBILE = 'MobileGPURenderer';
 export const RENDERER_TYPE_GPU_DESKTOP = 'DesktopGPURenderer';

--- a/test/emitter/Emitter.events.spec.js
+++ b/test/emitter/Emitter.events.spec.js
@@ -1,0 +1,139 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life } = Nebula;
+
+const STEP = 1 / 60;
+
+// A parent that emits one short-lived particle, carrying a `death`-trigger burst
+// child that fires once at the parent's death position.
+const build = ({
+  seed = 1,
+  parentX = 0,
+  parentLife = 0.1,
+  burstCount = 5,
+  childLife = 0.1,
+  withSmoke = false,
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(seed);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(parentLife, parentLife));
+  parent.setPosition({ x: parentX });
+
+  const burst = new Emitter();
+
+  burst
+    .setRate(new Rate(new Span(burstCount, burstCount), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife));
+  burst.trigger = 'death';
+  burst.emit(1); // one-shot burst
+
+  parent.addChild(burst);
+
+  if (withSmoke) {
+    const smoke = new Emitter();
+
+    smoke
+      .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+      .addInitializer(new Life(childLife, childLife));
+    // default trigger 'spawn' — attaches at birth
+    smoke.emit(Infinity, Infinity);
+    parent.addChild(smoke);
+  }
+
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent };
+};
+
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+const collectBurstParticleIds = system => {
+  const ids = [];
+
+  system._detached.forEach(inst => inst.particles.forEach(p => ids.push(p.id)));
+
+  return ids.sort();
+};
+
+describe('emitter -> Emitter -> events (death trigger)', () => {
+  it('does not instance a death-trigger child at parent birth', () => {
+    const { system, parent } = build();
+
+    step(system);
+
+    assert.isAbove(parent.particles.length, 0, 'parent alive');
+    assert.equal(parent.activeChildren.size, 0, 'nothing attached at birth');
+    assert.equal(system._liveEmitterInstances, 0);
+    assert.lengthOf(system._detached, 0);
+  });
+
+  it('bursts the child at the parent death position, outliving the parent', () => {
+    const { system, parent } = build({ parentX: 30, burstCount: 6 });
+
+    step(system, 10); // age the parent past its life
+
+    assert.lengthOf(parent.particles, 0, 'parent gone');
+    assert.lengthOf(system._detached, 1, 'one burst instance');
+
+    const burst = system._detached[0];
+
+    assert.equal(burst.particles.length, 6, 'burst emitted its particles');
+    assert.closeTo(burst.position.x, 30, 1e-9, 'positioned at death spot');
+    burst.particles.forEach(p =>
+      assert.closeTo(p.position.x, 30, 1e-6, 'burst particles at death spot')
+    );
+  });
+
+  it('drains and releases the burst — no leak', () => {
+    const { system } = build({ parentLife: 0.1, childLife: 0.1 });
+
+    step(system, 30);
+
+    assert.lengthOf(system._detached, 0, 'burst drained');
+    assert.equal(system._liveEmitterInstances, 0, 'instance released');
+  });
+
+  it('coexists with a spawn-trigger child: one attaches, the other bursts', () => {
+    const { system, parent } = build({ withSmoke: true });
+
+    step(system);
+    // Only the spawn child (smoke) attaches at birth.
+    assert.equal(parent.activeChildren.size, 1);
+    assert.equal(system._liveEmitterInstances, 1);
+
+    step(system, 10); // parent dies → smoke detaches, burst fires
+    // Two detached instances now: the drained-detaching smoke and the burst.
+    assert.isAtLeast(system._detached.length, 1);
+    const totalBurstParticles = system._detached.reduce(
+      (n, inst) => n + inst.particles.length,
+      0
+    );
+    assert.isAbove(totalBurstParticles, 0, 'burst produced particles');
+  });
+
+  it('is deterministic for a given seed', () => {
+    const a = build({ seed: 99 }).system;
+    const b = build({ seed: 99 }).system;
+
+    for (let i = 0; i < 12; i++) {
+      a.update(STEP);
+      b.update(STEP);
+    }
+
+    assert.deepEqual(collectBurstParticleIds(a), collectBurstParticleIds(b));
+  });
+});

--- a/test/emitter/Emitter.inheritance.spec.js
+++ b/test/emitter/Emitter.inheritance.spec.js
@@ -1,0 +1,217 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life, Radius } = Nebula;
+
+const STEP = 1 / 60;
+
+// A parent that emits one long-lived, stationary particle, carrying a child whose
+// inherit modes are set per-test. The parent particle stays put (no velocity), so
+// tests can move/scale it by hand and observe how the child responds.
+const build = ({
+  inherit = {},
+  childRadius = 10,
+  childLife = 100,
+  parentX = 0,
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(4242);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(100, 100));
+  parent.setPosition({ x: parentX });
+
+  const child = new Emitter();
+
+  child
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife))
+    .addInitializer(new Radius(childRadius, childRadius));
+  // Start from all-none and override per test, for isolation.
+  child.inherit = {
+    position: 'none',
+    rotation: 'none',
+    scale: 'none',
+    ...inherit,
+  };
+  child.emit(Infinity, Infinity);
+
+  parent.addChild(child);
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent };
+};
+
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+// The single child instance riding the single parent particle.
+const soleInstance = parent => {
+  const particle = parent.particles[0];
+
+  return { particle, instance: parent.activeChildren.get(particle)[0] };
+};
+
+describe('emitter -> Emitter -> inheritance modes', () => {
+  describe('position', () => {
+    it('always: the child tracks the parent every frame', () => {
+      const { system, parent } = build({
+        inherit: { position: 'always' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'snapshots at spawn');
+
+      particle.position.set(50, 60, 0);
+      step(system);
+
+      assert.closeTo(instance.position.x, 50, 1e-9, 'follows the parent');
+      assert.closeTo(instance.position.y, 60, 1e-9);
+    });
+
+    it('onCreate: the child snapshots at spawn then stays put', () => {
+      const { system, parent } = build({
+        inherit: { position: 'onCreate' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'snapshot taken');
+
+      particle.position.set(50, 0, 0);
+      step(system);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'does not follow');
+    });
+
+    it('none: the child ignores the parent (system space)', () => {
+      const { system, parent } = build({
+        inherit: { position: 'none' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.equal(instance.position.x, 0, 'stays in system space');
+
+      particle.position.set(50, 0, 0);
+      step(system);
+
+      assert.equal(instance.position.x, 0);
+    });
+  });
+
+  describe('rotation', () => {
+    it('always tracks, onCreate snapshots, none ignores', () => {
+      const always = build({ inherit: { rotation: 'always' } });
+      const onCreate = build({ inherit: { rotation: 'onCreate' } });
+      const none = build({ inherit: { rotation: 'none' } });
+
+      [always, onCreate, none].forEach(({ system }) => step(system));
+
+      const a = soleInstance(always.parent);
+      const o = soleInstance(onCreate.parent);
+      const n = soleInstance(none.parent);
+
+      // Spin every parent particle after spawn.
+      [a, o, n].forEach(({ particle }) => particle.rotation.set(1, 2, 3));
+      [always, onCreate, none].forEach(({ system }) => step(system));
+
+      assert.closeTo(a.instance.rotation.z, 3, 1e-9, 'always follows');
+      assert.equal(o.instance.rotation.z, 0, 'onCreate kept its 0 snapshot');
+      assert.equal(n.instance.rotation.z, 0, 'none ignores');
+    });
+  });
+
+  describe('scale', () => {
+    it('always: bakes the current parent scale into new child radii', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'always' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      instance.particles.forEach(p =>
+        assert.closeTo(p.radius, 10, 1e-6, 'parent scale 1 → radius unchanged')
+      );
+
+      particle.scale = 4;
+      step(system, 3);
+
+      const scaled = instance.particles.filter(p => p.radius > 30);
+
+      assert.isAbove(scaled.length, 0, 'new child particles grew with parent');
+    });
+
+    it('onCreate: snapshots the parent scale, ignoring later changes', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'onCreate' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      particle.scale = 4;
+      step(system, 3);
+
+      instance.particles.forEach(p =>
+        assert.closeTo(p.radius, 10, 1e-6, 'radius fixed at the spawn snapshot')
+      );
+    });
+
+    it('none: parent scale never touches child radius', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'none' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      particle.scale = 9;
+      step(system, 3);
+
+      instance.particles.forEach(p => assert.closeTo(p.radius, 10, 1e-6));
+    });
+  });
+
+  it('acceptance: flipping position always→onCreate turns an attached trail into a left-behind band', () => {
+    // Same system, one knob. `always` keeps the child pinned to the moving
+    // parent; `onCreate` leaves it where the parent was at spawn.
+    const attached = build({ inherit: { position: 'always' }, parentX: 5 });
+    const band = build({ inherit: { position: 'onCreate' }, parentX: 5 });
+
+    step(attached.system);
+    step(band.system);
+
+    const a = soleInstance(attached.parent);
+    const b = soleInstance(band.parent);
+
+    a.particle.position.set(200, 0, 0);
+    b.particle.position.set(200, 0, 0);
+    step(attached.system);
+    step(band.system);
+
+    assert.closeTo(a.instance.position.x, 200, 1e-9, 'attached: rides along');
+    assert.closeTo(b.instance.position.x, 5, 1e-9, 'band: stays behind');
+  });
+});

--- a/test/renderer/RibbonRenderer.spec.js
+++ b/test/renderer/RibbonRenderer.spec.js
@@ -1,0 +1,158 @@
+import * as THREE from 'three';
+
+import RibbonRenderer, {
+  bySpawnIndex,
+  ribbonIndices,
+} from '../../src/renderer/RibbonRenderer';
+import chai from 'chai';
+
+const { assert } = chai;
+
+// A minimal stand-in for a particle — the renderer only reads these fields.
+const particle = ({
+  instance = 'i0',
+  spawnIndex = 0,
+  x = 0,
+  y = 0,
+  z = 0,
+  scale = 1,
+} = {}) => ({
+  emitterInstanceId: instance,
+  emitterId: null,
+  spawnIndex,
+  position: new THREE.Vector3(x, y, z),
+  color: { r: 1, g: 1, b: 1 },
+  alpha: 1,
+  scale,
+});
+
+describe('renderer -> RibbonRenderer -> helpers', () => {
+  it('orders a spine by spawn index', () => {
+    const spine = [
+      particle({ spawnIndex: 2 }),
+      particle({ spawnIndex: 0 }),
+      particle({ spawnIndex: 1 }),
+    ].sort(bySpawnIndex);
+
+    assert.deepEqual(
+      spine.map(p => p.spawnIndex),
+      [0, 1, 2]
+    );
+  });
+
+  it('builds two triangles (6 indices) per segment', () => {
+    assert.deepEqual(ribbonIndices(1), [], 'no segments for a single point');
+    assert.lengthOf(ribbonIndices(2), 6, 'one segment');
+    assert.lengthOf(ribbonIndices(4), 18, 'three segments');
+    // First segment references points 0 and 1 (vertices 0..3).
+    assert.deepEqual(ribbonIndices(2), [0, 2, 1, 1, 2, 3]);
+  });
+});
+
+describe('renderer -> RibbonRenderer -> grouping', () => {
+  const makeRenderer = () =>
+    new RibbonRenderer(new THREE.Object3D(), THREE, { camera: undefined });
+
+  it('groups live particles by emitter instance', () => {
+    const r = makeRenderer();
+
+    r.onParticleCreated(particle({ instance: 'a', spawnIndex: 0 }));
+    r.onParticleCreated(particle({ instance: 'b', spawnIndex: 0 }));
+    r.onParticleCreated(particle({ instance: 'a', spawnIndex: 1 }));
+
+    assert.equal(r._groups.size, 2);
+    assert.lengthOf(r._groups.get('a'), 2);
+    assert.lengthOf(r._groups.get('b'), 1);
+  });
+
+  it('removes a dead particle and disposes an emptied ribbon', () => {
+    const r = makeRenderer();
+    const p0 = particle({ instance: 'a', spawnIndex: 0 });
+    const p1 = particle({ instance: 'a', spawnIndex: 1 });
+
+    r.onParticleCreated(p0);
+    r.onParticleCreated(p1);
+    r.onSystemUpdate(); // builds the ribbon mesh
+
+    assert.isTrue(r._ribbons.has('a'));
+
+    r.onParticleDead(p0);
+    assert.lengthOf(r._groups.get('a'), 1);
+
+    r.onParticleDead(p1);
+    assert.isFalse(r._groups.has('a'), 'group gone');
+    assert.isFalse(r._ribbons.has('a'), 'ribbon disposed');
+  });
+
+  it('falls back to emitterId, then a shared bucket, for the group key', () => {
+    const r = makeRenderer();
+
+    r.onParticleCreated({
+      ...particle(),
+      emitterInstanceId: null,
+      emitterId: 'node0',
+    });
+    r.onParticleCreated({
+      ...particle(),
+      emitterInstanceId: null,
+      emitterId: null,
+    });
+
+    assert.isTrue(r._groups.has('node0'));
+    assert.isTrue(r._groups.has('ribbon'));
+  });
+});
+
+describe('renderer -> RibbonRenderer -> rebuild', () => {
+  const makeRenderer = () => new RibbonRenderer(new THREE.Object3D(), THREE);
+
+  it('hides a strip with fewer than two live points', () => {
+    const r = makeRenderer();
+
+    r.onParticleCreated(particle({ instance: 'a' }));
+    r.onSystemUpdate();
+
+    assert.isFalse(r._ribbons.get('a').mesh.visible);
+  });
+
+  it('builds a visible, NaN-free strip and sets the draw range', () => {
+    const r = makeRenderer();
+
+    for (let i = 0; i < 4; i++) {
+      r.onParticleCreated(
+        particle({ instance: 'a', spawnIndex: i, x: i * 10 })
+      );
+    }
+
+    r.onSystemUpdate();
+
+    const ribbon = r._ribbons.get('a');
+
+    assert.isTrue(ribbon.mesh.visible);
+    // 4 points → 3 segments → 18 indices.
+    assert.equal(ribbon.geometry.drawRange.count, 18);
+    assert.isAtLeast(ribbon.capacity, 4);
+
+    const pos = ribbon.geometry.attributes.position.array;
+    for (let i = 0; i < 4 * 6; i++) {
+      assert.isFalse(Number.isNaN(pos[i]), `position[${i}] is finite`);
+    }
+  });
+
+  it('grows buffers as the spine lengthens, keeping the high-water capacity', () => {
+    const r = makeRenderer();
+
+    for (let i = 0; i < 3; i++) {
+      r.onParticleCreated(particle({ instance: 'a', spawnIndex: i, x: i }));
+    }
+    r.onSystemUpdate();
+    assert.isAtLeast(r._ribbons.get('a').capacity, 3);
+
+    for (let i = 3; i < 12; i++) {
+      r.onParticleCreated(particle({ instance: 'a', spawnIndex: i, x: i }));
+    }
+    r.onSystemUpdate();
+    assert.isAtLeast(r._ribbons.get('a').capacity, 12);
+    assert.equal(r._ribbons.get('a').geometry.drawRange.count, 11 * 6);
+  });
+});


### PR DESCRIPTION
Fifth and final PR in the emitter-hierarchy (spec 01) stack. **Base is the Stage 4 branch** `feat/emitter-hierarchy-ribbon` (PR #323). Completes spec 01.

## What this adds

Child emitters gain a `trigger`:
- **`spawn`** (default) — *attachment*: instanced at the parent particle's birth, riding it (Stages 2–3). Unchanged behaviour.
- **`death`** — *event*: instanced at the parent particle's **death**, bursting once at that position and **outliving** the parent (fireworks).

The distinction is *when* the child is instanced; attachment vs. events, exactly as the spec frames it.

## How

- `_spawnChildrenFor` only attaches `spawn` children at birth; `death` children are held back.
- `_triggerDeathChildren` fires them in the dead sweep, **before** the particle is reset (so the death position is still valid). The burst is placed at the death spot and handed to `System._detachInstance(inst, stopEmitting: false)` — it keeps emitting long enough to fire its one-shot burst, then drains and releases through the existing detached path. **No leak.**
- Recurses (a burst's own particles can spawn/burst their own children), bounded by `maxDepth`.
- Schema: `EmitterJSON` gains optional `trigger`; both `fromJSON` paths set it.

## Tests / demo

`test/emitter/Emitter.events.spec.js` — not instanced at birth; bursts at the death position; drains and releases (no leak); coexists with a `spawn` child; deterministic. Full suite **317 pass**; tsc/lint/format/madge clean.

`npm run sandbox` → "Emitter Events — fireworks": rockets whose death bursts a coloured shell.

## Spec 01 complete

Stages 1–5 all landed. `onCollision` events are noted as a future extension (three-nebula has no general collision system yet). Two follow-up specs were filed separately: the SphereZone centre-Y/Z bug and per-emitter renderer routing.