### PR TITLE
Emitter Hierarchy (spec 01) — umbrella: nested emitters, inheritance, ribbons, events

### DIFF
--- a/sandbox/experiments/emitter-hierarchy/index.html
+++ b/sandbox/experiments/emitter-hierarchy/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Emitter Hierarchy — sparks leaving smoke trails</title>
+    <title>Emitter Hierarchy — healing aura</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />

--- a/sandbox/experiments/emitter-hierarchy/index.html
+++ b/sandbox/experiments/emitter-hierarchy/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Emitter Hierarchy — sparks leaving smoke trails</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -18,10 +18,18 @@ import System, {
 import { run } from '/common/run.js';
 
 // Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
-// outward; each spark rides a child "smoke" emitter (inherit.position: 'always',
-// orphanPolicy: 'detach') so the smoke follows its spark and lives on after the
-// spark dies. One child node → one live instance per spark, all recycled through
-// the Stage 1 pool.
+// outward; each spark rides a child "smoke" emitter (orphanPolicy: 'detach') so
+// the smoke follows its spark and lives on after the spark dies. One child node →
+// one live instance per spark, all recycled through the Stage 1 pool.
+//
+// Stage 3 inheritance modes are on show:
+//   - scale: 'always'    smoke puffs shrink as the spark shrinks
+//   - position: 'always' (default) smoke rides the spark; append
+//     ?position=onCreate to leave a stationary band where each spark was born.
+const positionMode =
+  new URLSearchParams(window.location.search).get('position') === 'onCreate'
+    ? 'onCreate'
+    : 'always';
 
 const createSprite = color => {
   const map = new THREE.TextureLoader().load('/assets/dot.png');
@@ -55,8 +63,9 @@ const createSmokeTrail = () => {
       new Color('#aaaaaa', '#222222'),
     ]);
 
-  // Follow the parent spark every frame; let emitted smoke outlive the spark.
-  smoke.inherit = { position: 'always', rotation: 'none', scale: 'none' };
+  // Track the spark's position (see positionMode) and shrink with it (scale);
+  // let emitted smoke outlive the spark.
+  smoke.inherit = { position: positionMode, rotation: 'none', scale: 'always' };
   smoke.orphanPolicy = 'detach';
   smoke.emit(Infinity, Infinity);
 

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -7,29 +7,38 @@ import System, {
   Force,
   Life,
   Mass,
+  Position,
   RadialVelocity,
   Radius,
+  RandomDrift,
   Rate,
   Scale,
+  SphereZone,
   Span,
+  VectorVelocity,
   GPURenderer,
   Vector3D,
 } from 'three-nebula';
 import { run } from '/common/run.js';
 
-// Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
-// outward; each spark rides a child "smoke" emitter (orphanPolicy: 'detach') so
-// the smoke follows its spark and lives on after the spark dies. One child node →
-// one live instance per spark, all recycled through the Stage 1 pool.
+// Healing aura — a designed showcase of the emitter hierarchy (spec 01).
 //
-// Stage 3 inheritance modes are on show:
-//   - scale: 'always'    smoke puffs shrink as the spark shrinks
-//   - position: 'always' (default) smoke rides the spark; append
-//     ?position=onCreate to leave a stationary band where each spark was born.
+// A ground cluster lifts soft green→gold "motes" (parent). Each mote rides a
+// child "sparkle" emitter that inherits its transform, so the sparkles ride the
+// mote up the column and — because scale is inherited — shrink as the mote fades.
+// orphanPolicy 'detach' lets a mote's sparkles twinkle out on their own after the
+// mote dies. One child node → one live sparkle emitter per mote, all recycled
+// through the pool.
+//
+// Append ?position=onCreate to switch the sparkles from riding the mote (a
+// trailing shimmer) to snapping to where the mote was born (a standing pillar of
+// light) — the Stage 3 always↔onCreate contrast.
 const positionMode =
   new URLSearchParams(window.location.search).get('position') === 'onCreate'
     ? 'onCreate'
     : 'always';
+
+const BASE_Y = -120;
 
 const createSprite = color => {
   const map = new THREE.TextureLoader().load('/assets/dot.png');
@@ -44,64 +53,70 @@ const createSprite = color => {
   );
 };
 
-// The child: a slow, greying puff that trails whichever spark spawned it.
-const createSmokeTrail = () => {
-  const smoke = new Emitter();
+// The child: a small, bright twinkle that rides (or is left behind by) its mote.
+const createSparkles = () => {
+  const sparkles = new Emitter();
 
-  smoke
-    .setRate(new Rate(new Span(1, 2), new Span(0.02, 0.04)))
+  sparkles
+    .setRate(new Rate(new Span(1, 2), new Span(0.03, 0.06)))
     .setInitializers([
       new Mass(1),
-      new Life(0.6, 1.1),
-      new Body(createSprite(0x888888)),
-      new Radius(16, 32),
-      new RadialVelocity(15, new Vector3D(0, 1, 0), 30),
-    ])
-    .setBehaviours([
-      new Alpha(0.35, 0),
-      new Scale(0.5, 1.6),
-      new Color('#aaaaaa', '#222222'),
-    ]);
-
-  // Track the spark's position (see positionMode) and shrink with it (scale);
-  // let emitted smoke outlive the spark.
-  smoke.inherit = { position: positionMode, rotation: 'none', scale: 'always' };
-  smoke.orphanPolicy = 'detach';
-  smoke.emit(Infinity, Infinity);
-
-  return smoke;
-};
-
-// The parent: bright, fast sparks under gravity, each carrying a smoke child.
-const createSparks = () => {
-  const sparks = new Emitter();
-
-  sparks
-    .setRate(new Rate(new Span(2, 4), new Span(0.06, 0.1)))
-    .setInitializers([
-      new Mass(1),
-      new Life(1.1, 1.7),
-      new Body(createSprite(0xffcc33)),
-      new Radius(26, 46),
-      new RadialVelocity(220, new Vector3D(0, 1, 0), 55),
+      new Life(0.35, 0.7),
+      new Body(createSprite(0xffffff)),
+      new Radius(3, 6),
+      new RadialVelocity(16, new Vector3D(0, 1, 0), 70),
     ])
     .setBehaviours([
       new Alpha(1, 0),
-      new Scale(1, 0.25),
-      new Color('#fffb00', '#ff3c00'),
-      new Force(0, -140, 0),
+      new Color('#ffffff', '#ffd86b'),
+      new Scale(1, 0.1),
     ]);
 
-  sparks.addChild(createSmokeTrail());
+  // Ride the mote (position) and shrink with it (scale); linger after it dies.
+  sparkles.inherit = {
+    position: positionMode,
+    rotation: 'none',
+    scale: 'always',
+  };
+  sparkles.orphanPolicy = 'detach';
+  sparkles.emit(Infinity, Infinity);
 
-  return sparks.emit();
+  return sparkles;
+};
+
+// The parent: soft motes rising from a base cluster, greening into gold.
+const createMotes = () => {
+  const motes = new Emitter();
+
+  motes
+    .setRate(new Rate(new Span(3, 5), new Span(0.02, 0.04)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1.6, 2.6),
+      new Body(createSprite(0xffffff)),
+      new Radius(8, 16),
+      new Position(new SphereZone(45)),
+      new VectorVelocity(new Vector3D(0, 90, 0), 25),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Color('#7cffb0', '#ffe68a'),
+      new Scale(0.7, 1.5),
+      new RandomDrift(18, 8, 18, 0.1),
+      new Force(0, 30, 0),
+    ]);
+
+  motes.setPosition({ x: 0, y: BASE_Y, z: 0 });
+  motes.addChild(createSparkles());
+
+  return motes.emit();
 };
 
 const init = async ({ scene }) => {
   const system = new System();
 
   return system
-    .addEmitter(createSparks())
+    .addEmitter(createMotes())
     .addRenderer(new GPURenderer(scene, THREE));
 };
 

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -1,0 +1,99 @@
+import * as THREE from 'three';
+import System, {
+  Alpha,
+  Body,
+  Color,
+  Emitter,
+  Force,
+  Life,
+  Mass,
+  RadialVelocity,
+  Radius,
+  Rate,
+  Scale,
+  Span,
+  GPURenderer,
+  Vector3D,
+} from 'three-nebula';
+import { run } from '/common/run.js';
+
+// Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
+// outward; each spark rides a child "smoke" emitter (inherit.position: 'always',
+// orphanPolicy: 'detach') so the smoke follows its spark and lives on after the
+// spark dies. One child node → one live instance per spark, all recycled through
+// the Stage 1 pool.
+
+const createSprite = color => {
+  const map = new THREE.TextureLoader().load('/assets/dot.png');
+
+  return new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map,
+      color,
+      blending: THREE.AdditiveBlending,
+      fog: true,
+    })
+  );
+};
+
+// The child: a slow, greying puff that trails whichever spark spawned it.
+const createSmokeTrail = () => {
+  const smoke = new Emitter();
+
+  smoke
+    .setRate(new Rate(new Span(1, 2), new Span(0.02, 0.04)))
+    .setInitializers([
+      new Mass(1),
+      new Life(0.6, 1.1),
+      new Body(createSprite(0x888888)),
+      new Radius(16, 32),
+      new RadialVelocity(15, new Vector3D(0, 1, 0), 30),
+    ])
+    .setBehaviours([
+      new Alpha(0.35, 0),
+      new Scale(0.5, 1.6),
+      new Color('#aaaaaa', '#222222'),
+    ]);
+
+  // Follow the parent spark every frame; let emitted smoke outlive the spark.
+  smoke.inherit = { position: 'always', rotation: 'none', scale: 'none' };
+  smoke.orphanPolicy = 'detach';
+  smoke.emit(Infinity, Infinity);
+
+  return smoke;
+};
+
+// The parent: bright, fast sparks under gravity, each carrying a smoke child.
+const createSparks = () => {
+  const sparks = new Emitter();
+
+  sparks
+    .setRate(new Rate(new Span(2, 4), new Span(0.06, 0.1)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1.1, 1.7),
+      new Body(createSprite(0xffcc33)),
+      new Radius(26, 46),
+      new RadialVelocity(220, new Vector3D(0, 1, 0), 55),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Scale(1, 0.25),
+      new Color('#fffb00', '#ff3c00'),
+      new Force(0, -140, 0),
+    ]);
+
+  sparks.addChild(createSmokeTrail());
+
+  return sparks.emit();
+};
+
+const init = async ({ scene }) => {
+  const system = new System();
+
+  return system
+    .addEmitter(createSparks())
+    .addRenderer(new GPURenderer(scene, THREE));
+};
+
+run(init, { shouldRotateCamera: false, shouldAddCameraControls: true });

--- a/sandbox/experiments/fireworks/index.html
+++ b/sandbox/experiments/fireworks/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Emitter Events — fireworks (burst on death)</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/fireworks/index.js
+++ b/sandbox/experiments/fireworks/index.js
@@ -1,0 +1,117 @@
+import * as THREE from 'three';
+import System, {
+  Alpha,
+  Body,
+  Color,
+  Emitter,
+  Force,
+  Life,
+  Mass,
+  RadialVelocity,
+  Radius,
+  Rate,
+  Scale,
+  Span,
+  GPURenderer,
+  Vector3D,
+} from 'three-nebula';
+import { run } from '/common/run.js';
+
+// Emitter events (spec 01, Stage 5). Each rocket is a parent emitter whose
+// particles rise and die mid-air; a `trigger: 'death'` child bursts a shell of
+// sparks at the death position and outlives the rocket. Unlike attachment
+// (Stages 2–3), the burst is instanced *at death*, not birth. One GPURenderer
+// draws rockets and sparks alike (points), so no per-emitter routing is needed.
+
+const PALETTE = [
+  ['#fff6a0', '#ff5a3c'], // gold → red
+  ['#a0f0ff', '#2a6cff'], // cyan → blue
+  ['#ffc0f0', '#c030ff'], // pink → purple
+];
+
+const UP = new Vector3D(0, 1, 0);
+const BASE_Y = -150;
+
+const createSprite = () => {
+  const map = new THREE.TextureLoader().load('/assets/dot.png');
+
+  return new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map,
+      color: 0xffffff,
+      blending: THREE.AdditiveBlending,
+      fog: true,
+    })
+  );
+};
+
+// The shell: a one-shot radial burst that fires when its rocket dies.
+const createBurst = ([colorA, colorB]) => {
+  const burst = new Emitter();
+
+  burst
+    .setRate(new Rate(new Span(60, 90), new Span(0.01, 0.01)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1, 1.7),
+      new Body(createSprite()),
+      new Radius(6, 12),
+      new RadialVelocity(new Span(130, 230), UP, 180), // omnidirectional
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Color(colorA, colorB),
+      new Scale(1, 0.3),
+      // Force is scaled ×100 internally (MEASURE), so this is ~100 units/s² down.
+      new Force(0, -1, 0),
+    ]);
+
+  burst.trigger = 'death'; // instanced at the rocket's death, not its birth
+  burst.emit(1); // one-shot
+
+  return burst;
+};
+
+// The rocket: rises from the base, arcs under gravity, dies mid-air.
+const createRocket = (palette, x) => {
+  const rocket = new Emitter();
+
+  rocket
+    .setRate(new Rate(new Span(1, 1), new Span(0.7, 1.1)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1, 1.4),
+      new Body(createSprite()),
+      new Radius(7, 11),
+      new RadialVelocity(300, UP, 18),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0.7),
+      new Color('#ffffff', palette[0]),
+      new Scale(1, 0.6),
+      // ~160 units/s² down (×100 MEASURE); rocket dies while still rising.
+      new Force(0, -1.6, 0),
+    ]);
+
+  rocket.setPosition({ x, y: BASE_Y });
+  rocket.addChild(createBurst(palette));
+
+  return rocket.emit();
+};
+
+const init = async ({ scene, camera }) => {
+  const system = new System();
+  const spread = [-150, 0, 150];
+
+  PALETTE.forEach((palette, i) =>
+    system.addEmitter(createRocket(palette, spread[i]))
+  );
+  system.addRenderer(new GPURenderer(scene, THREE));
+
+  camera.position.set(0, 20, 560);
+  camera.lookAt(0, 20, 0);
+
+  return system;
+};
+
+run(init, { shouldRotateCamera: false, shouldAddCameraControls: true });

--- a/sandbox/experiments/ribbon-trails/index.html
+++ b/sandbox/experiments/ribbon-trails/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Ribbon Renderer — flowing trails</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" type="text/css" href="/style/reset.css" />
+    <link rel="stylesheet" type="text/css" href="/style/app.css" />
+  </head>
+
+  <body>
+    <div id="app">
+      <canvas id="canvas"></canvas>
+    </div>
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/sandbox/experiments/ribbon-trails/index.js
+++ b/sandbox/experiments/ribbon-trails/index.js
@@ -1,0 +1,81 @@
+import * as THREE from 'three';
+import System, {
+  Alpha,
+  Color,
+  Emitter,
+  Life,
+  Mass,
+  Rate,
+  Scale,
+  Span,
+  RibbonRenderer,
+} from 'three-nebula';
+import { run } from '/common/run.js';
+
+// Ribbon renderer (spec 01, Stage 4). Each emitter lays a dense, stationary
+// stream of short-lived particles as it flies along a path; the RibbonRenderer
+// connects each emitter's particles (its spine, in spawn order) into one
+// continuous, camera-facing strip. Several emitters → several ribbons, keyed by
+// emitterInstanceId — the per-instance grouping the hierarchy relies on.
+
+const PALETTE = [
+  ['#00ffa3', '#0066ff'],
+  ['#ff4d6d', '#ffd166'],
+  ['#8a5cff', '#00e5ff'],
+];
+
+// A ribbon emitter emits a fast, dense stream of near-stationary particles (so
+// they stay on the path) that fade and taper (Scale → 0) toward the tail.
+const createRibbonEmitter = ([colorA, colorB]) => {
+  const emitter = new Emitter();
+
+  return emitter
+    .setRate(new Rate(new Span(2, 3), new Span(0.006, 0.012)))
+    .setInitializers([new Mass(1), new Life(0.9, 1.3)])
+    .setBehaviours([
+      new Color(colorA, colorB),
+      new Scale(1, 0),
+      new Alpha(1, 0),
+    ])
+    .emit();
+};
+
+// Fly each emitter along a phase-shifted Lissajous path; particles are left
+// behind on the path, so the ribbon traces where the emitter has been.
+const fly = (emitters, t = 0) => {
+  t += 0.016;
+
+  emitters.forEach((emitter, i) => {
+    const phase = (i / emitters.length) * Math.PI * 2;
+    const r = 120;
+
+    emitter.position.x = r * Math.cos(t * 1.1 + phase);
+    emitter.position.y = r * 0.6 * Math.sin(t * 1.7 + phase);
+    emitter.position.z = r * 0.45 * Math.sin(t * 0.9 + phase);
+  });
+
+  requestAnimationFrame(() => fly(emitters, t));
+};
+
+const init = async ({ scene, camera }) => {
+  const system = new System();
+  const emitters = PALETTE.map(createRibbonEmitter);
+  const renderer = new RibbonRenderer(scene, THREE, {
+    camera,
+    width: 16,
+    blending: 'AdditiveBlending',
+    uv: 'stretch',
+  });
+
+  // Pull back so the whole ±120 path is framed.
+  camera.position.set(0, 0, 440);
+  camera.lookAt(0, 0, 0);
+
+  emitters.forEach(emitter => system.addEmitter(emitter));
+  system.addRenderer(renderer);
+  fly(emitters);
+
+  return system;
+};
+
+run(init, { shouldRotateCamera: false, shouldAddCameraControls: true });

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,8 +12,8 @@
       <ul>
         <li>
           <a href="experiments/emitter-hierarchy/index.html">
-            Emitter Hierarchy — sparks leaving smoke trails (child emitters) —
-            add ?position=onCreate for left-behind bands
+            Emitter Hierarchy — healing aura (motes each trailing a sparkle
+            child) — add ?position=onCreate for a standing pillar
           </a>
         </li>
         <li>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -11,6 +11,11 @@
     <nav>
       <ul>
         <li>
+          <a href="experiments/emitter-hierarchy/index.html">
+            Emitter Hierarchy — sparks leaving smoke trails (child emitters)
+          </a>
+        </li>
+        <li>
           <a href="experiments/determinism/index.html">
             Determinism — same seed, same result (toggle "desync" to diverge)
           </a>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -22,6 +22,11 @@
           </a>
         </li>
         <li>
+          <a href="experiments/fireworks/index.html">
+            Emitter Events — fireworks (rockets burst on death)
+          </a>
+        </li>
+        <li>
           <a href="experiments/determinism/index.html">
             Determinism — same seed, same result (toggle "desync" to diverge)
           </a>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -17,6 +17,11 @@
           </a>
         </li>
         <li>
+          <a href="experiments/ribbon-trails/index.html">
+            Ribbon Renderer — flowing camera-facing trails (one strip per emitter)
+          </a>
+        </li>
+        <li>
           <a href="experiments/determinism/index.html">
             Determinism — same seed, same result (toggle "desync" to diverge)
           </a>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,7 +12,8 @@
       <ul>
         <li>
           <a href="experiments/emitter-hierarchy/index.html">
-            Emitter Hierarchy — sparks leaving smoke trails (child emitters)
+            Emitter Hierarchy — sparks leaving smoke trails (child emitters) —
+            add ?position=onCreate for left-behind bands
           </a>
         </li>
         <li>

--- a/specs/01-emitter-hierarchy.md
+++ b/specs/01-emitter-hierarchy.md
@@ -47,6 +47,92 @@ Before writing code, establish:
 **Write the answers into this spec before proceeding.** Stages 1–4 assume answers
 that may be wrong.
 
+### Audit findings (recorded 2026-08-26, against `develop` @ post-13.0.0)
+
+**1. Particle pooling — exists, global, System-owned.**
+`src/core/Pool.ts` — API is `get<T>(obj, ...args)` / `expire(obj)` (not `acquire`/
+`release`). One pool per System (`System.ts` `this.pool = new Pool()`), **shared by
+all emitters**; emitters reach it via `this.system.pool`. Acquire in
+`Emitter.createParticle()` (`pool.get(Particle)`); release in `Emitter.update()`'s
+dead-particle loop (`pool.expire(particle.reset())`). **No emitter pool exists** —
+emitters are `new`'d once, long-lived, spliced out on removal, never recycled. Stage 1's
+emitter-instance pool is genuinely new work.
+
+**2. Particle ID — stable, deterministic, survives pool reuse.**
+Format `particle-${emitterSeed}-${spawnIndex}`, assigned in `Emitter.setupParticle()`,
+NOT in the constructor (which sets a throwaway uuid). `spawnIndex` is a monotonic
+`_spawnCount++` per emitter. `Particle.reset()` deliberately does **not** clear `id`, so
+the id is valid for the whole life and is only overwritten at the next `setupParticle`.
+Good enough to key child-instance seeds off — but see risk (A).
+
+**3. Renderer interface — System-level, event-driven. THIS IS THE KEY CONSTRAINT.**
+`src/renderer/BaseRenderer.ts`. Hooks: `init(system)`, `onSystemUpdate(system)`,
+`onParticleCreated(particle)`, `onParticleUpdate(particle)`, `onParticleDead(particle)`,
+`remove(system)`, optional `destroy()`. Renderers attach to the **System**
+(`system.addRenderer` → `renderer.init(system)`), *not* to emitters. They receive work
+purely through the System's `eventDispatcher` (`PARTICLE_CREATED/UPDATE/DEAD`,
+`SYSTEM_UPDATE`). **A renderer cannot today be scoped to one emitter, and a particle
+carries no emitter back-reference a renderer could switch on.** The spec's per-child
+`renderer: {...}` block collides with this — see risk (B).
+
+**4. Update ordering — flat, reverse iteration.**
+`System.update(delta)` runs `while (i--)` over `emitters` (reverse array order), calling
+`emitter.update(delta)`, then dispatches `SYSTEM_UPDATE` if that emitter has particles;
+`SYSTEM_UPDATE_AFTER` once at the end. `tick(realDt)` is the fixed-step accumulator that
+calls `update(fixedTimeStep)` N times. Within `Emitter.update`: `generate` (rate→
+`createParticle`) → `integrate` (behaviours + physics, dispatch `PARTICLE_UPDATE`) →
+dead-particle sweep (dispatch `PARTICLE_DEAD`, `pool.expire`, splice) →
+`updateEmitterBehaviours`. There is no topological/tree ordering — the tree walk in
+Stage 2 is new control flow we add.
+
+**5. Emitter-to-emitter references — none.**
+`System.emitters: Emitter[]` is a flat sibling list. No `children`/`parent`/sub-emitter
+concept. Note `Emitter extends Particle`, so `emitter.parent` exists but is typed
+`Emitter | System | null` and only ever holds the System. `emitter.particles` is
+`Particle[]`, never emitters. Clean slate for hierarchy.
+
+**6. JSON schema — unversioned; flat emitter list.**
+`src/core/fromJSON.ts` (+ `fromJSONAsync.ts`). `SystemJSON = { preParticles?,
+integrationType?, emitters? }`; `EmitterJSON = { rate, rotation?, position?,
+initializers, behaviours, emitterBehaviours?, totalEmitTimes?, life?, damping? }`.
+**No `version` field, and no emitter `id` field.** Initializers/behaviours rebuilt via
+hard-coded `INITIALIZERS`/`BEHAVIOURS` lookup tables → static `fromJSON`. Adding
+`children[]` is additive; adding a stable emitter `id` (needed for child seeds — risk A)
+is also additive but new.
+
+**Seeding (from 02, relevant to child seeds):** `System.seed` → `emitter.reseed(seed,
+index)` sets `emitter.seed = hashSeed(systemSeed, index)` → `particle.rng =
+mulberry32(hashSeed(emitterSeed, spawnIndex))`. Utilities: `hashSeed(...parts)` (FNV-1a
+over `parts.join(' ')`, accepts strings *or* numbers) and `mulberry32` in
+`src/math/rng.ts`. `hashSeed` taking strings is convenient — a child instance seed can be
+`hashSeed(emitterSeed, parentParticleId)` directly.
+
+### Risks / spec contradictions to resolve before Stage 2
+
+- **(A) Child seed key.** Spec says child seeds derive from `hash(systemSeed, emitterId,
+  parentParticleId)` but emitters have no stable string `id` — they key off array
+  `index`. Either add an optional `id` to emitters (preferred; also useful for tooling)
+  or derive from the definition's tree-path index. Parent particle id is stable and
+  usable as-is.
+- **(B) Renderer scoping is the crux.** Child particles need to render, but renderers are
+  System-level and event-routed with no emitter discriminator on the particle. Options,
+  cheapest first: **(B1)** child emitters share the system's renderers — drop the
+  per-child `renderer` block for v1, all particles flow through existing System renderers
+  (smallest change, but no distinct look per child); **(B2)** stamp an emitter/definition
+  ref onto each particle and let a renderer filter — needs a particle field + renderer
+  changes; **(B3)** make renderers attachable per-emitter — largest change, touches the
+  event-dispatch model. Recommend deciding B before committing to Stage 2's JSON.
+- **(C) `detach` orphan policy vs pooling.** Default `orphanPolicy: "detach"` means a
+  dead parent's child *instance* is recycled while its already-emitted particles must
+  live on. Those particles live in `childInstance.particles`; recycling the instance
+  needs their ownership transferred (to the System or a survivor list) or they vanish.
+  This is the sharp edge where Stage 1 (pooling) and Stage 2 (lifecycle) meet.
+- **(D) `Emitter extends Particle`.** A child instance riding a parent is literally an
+  Emitter whose transform tracks a Particle each frame — `always` inheritance is a
+  per-frame `position.copy(parentParticle.position)`. The existing inheritance is a nice
+  fit, but watch that the emitter's own Particle-integration (`integrate(this, ...)`)
+  doesn't fight the tracked transform.
+
 ---
 
 ## Stage 1 — Pooling foundation

--- a/src/core/Particle.ts
+++ b/src/core/Particle.ts
@@ -65,11 +65,17 @@ export default class Particle {
   hasBeenInitialized?: boolean;
   // Set by Emitter.setupParticle — the particle's index within its emitter.
   index?: number;
-  // Emitter hierarchy (spec 01): the tree-path id of the emitter that spawned
-  // this particle (null for top-level emitters). Stamped in Emitter.setupParticle
-  // and, like `id`, deliberately preserved across pooling until the next setup
-  // overwrites it. Renderers/ribbon grouping key off this without re-hashing.
+  // Emitter hierarchy (spec 01): the tree-path id of the emitter *definition*
+  // that spawned this particle (null for a flat top-level emitter). Shared by all
+  // instances of one node — the "which kind of thing" key (look/config).
   emitterId: string | null;
+  // The specific emitting *instance* (spec 01, Stage 4): the emitter's seed as a
+  // string. Unique per live emitter — every instance of a child node has its own —
+  // so the RibbonRenderer groups particles into one strip per trail. `spawnIndex`
+  // is the monotonic order within that instance, giving the strip its spine order.
+  // Both are stamped in setupParticle and preserved across pooling like `id`.
+  emitterInstanceId: string | null;
+  spawnIndex: number;
   // The particle's own seeded PRNG stream (Stage 2). Assigned by
   // Emitter.setupParticle from the emitter seed + a monotonic spawn index, so a
   // particle's randomness is a pure function of who spawned it and when.
@@ -87,6 +93,8 @@ export default class Particle {
   constructor(properties: Record<string, unknown> = {}) {
     this.id = `particle-${uid()}`;
     this.emitterId = null;
+    this.emitterInstanceId = null;
+    this.spawnIndex = 0;
     this.type = type;
     this.life = DEFAULT_LIFE;
     this.age = DEFAULT_AGE;

--- a/src/core/Particle.ts
+++ b/src/core/Particle.ts
@@ -65,6 +65,11 @@ export default class Particle {
   hasBeenInitialized?: boolean;
   // Set by Emitter.setupParticle — the particle's index within its emitter.
   index?: number;
+  // Emitter hierarchy (spec 01): the tree-path id of the emitter that spawned
+  // this particle (null for top-level emitters). Stamped in Emitter.setupParticle
+  // and, like `id`, deliberately preserved across pooling until the next setup
+  // overwrites it. Renderers/ribbon grouping key off this without re-hashing.
+  emitterId: string | null;
   // The particle's own seeded PRNG stream (Stage 2). Assigned by
   // Emitter.setupParticle from the emitter seed + a monotonic spawn index, so a
   // particle's randomness is a pure function of who spawned it and when.
@@ -81,6 +86,7 @@ export default class Particle {
    */
   constructor(properties: Record<string, unknown> = {}) {
     this.id = `particle-${uid()}`;
+    this.emitterId = null;
     this.type = type;
     this.life = DEFAULT_LIFE;
     this.age = DEFAULT_AGE;

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -1,11 +1,13 @@
 import EventDispatcher, {
   EMITTER_ADDED,
   EMITTER_REMOVED,
+  PARTICLE_DEAD,
   SYSTEM_UPDATE,
   SYSTEM_UPDATE_AFTER,
 } from '../events';
 
 import {
+  DEFAULT_MAX_DEPTH,
   DEFAULT_MAX_EMITTER_INSTANCES,
   DEFAULT_MAX_SUB_STEPS,
   DEFAULT_SYSTEM_DELTA,
@@ -68,6 +70,12 @@ export default class System {
   _emitterPoolHits: number;
   _emitterPoolMisses: number;
   _warnedInstanceOverflow: boolean;
+  // Hard recursion cap on the emitter tree (spec 01, Stage 2), enforced when an
+  // emitter is added. Detached child instances outlive their dead parent to let
+  // their particles drain (orphanPolicy 'detach'); the System advances them each
+  // frame and releases them once empty.
+  maxEmitterDepth: number;
+  _detached: Emitter[];
 
   constructor(
     preParticles: number = POOL_MAX,
@@ -91,6 +99,8 @@ export default class System {
     this._emitterPoolHits = 0;
     this._emitterPoolMisses = 0;
     this._warnedInstanceOverflow = false;
+    this.maxEmitterDepth = DEFAULT_MAX_DEPTH;
+    this._detached = [];
   }
 
   /**
@@ -119,6 +129,11 @@ export default class System {
     const warm = node._freeInstances.length > 0;
     const inst = node.acquireInstance(parentParticle);
 
+    // Parent the instance to the System (not the spawning emitter) so its own
+    // createParticle/update dispatch through the System's event stream — the same
+    // path top-level emitters use, so child particles reach the renderers (B1).
+    inst.parent = this;
+
     warm ? this._emitterPoolHits++ : this._emitterPoolMisses++;
     this._liveEmitterInstances++;
 
@@ -132,6 +147,81 @@ export default class System {
   releaseEmitterInstance(inst: Emitter): void {
     (inst._template as Emitter).releaseInstance(inst);
     this._liveEmitterInstances--;
+  }
+
+  /**
+   * Detaches a child instance from its dead parent: it stops emitting but keeps
+   * updating so its already-emitted particles live out their lives, then is
+   * released once drained (see `_updateDetached`). This is the `detach` policy.
+   */
+  _detachInstance(inst: Emitter): void {
+    inst.isEmitting = false;
+    inst._parentParticle = null;
+    this._detached.push(inst);
+  }
+
+  /**
+   * Kills a child instance with its parent (the `kill` policy): recursively kills
+   * its own descendants, expires its particles (dispatching PARTICLE_DEAD so
+   * renderers free them), then releases it immediately.
+   */
+  _killInstance(inst: Emitter): void {
+    inst.isEmitting = false;
+
+    if (inst.activeChildren.size) {
+      inst.activeChildren.forEach(instances => {
+        for (let i = 0; i < instances.length; i++) {
+          this._killInstance(instances[i]);
+        }
+      });
+      inst.activeChildren.clear();
+    }
+
+    let i = inst.particles.length;
+
+    while (i--) {
+      const particle = inst.particles[i];
+
+      this.dispatch(PARTICLE_DEAD, particle);
+      this.pool.expire(particle.reset());
+    }
+
+    inst.particles.length = 0;
+    this.releaseEmitterInstance(inst);
+  }
+
+  /**
+   * Advances detached instances (parents already dead) and releases each once it
+   * has fully drained. Runs after the emitter walk so freshly-detached instances
+   * still tick this frame. Flushes SYSTEM_UPDATE if any still hold particles so
+   * renderer buffers pick up their movement.
+   */
+  _updateDetached(time: number): void {
+    if (!this._detached.length) {
+      return;
+    }
+
+    let flushed = false;
+    let i = this._detached.length;
+
+    while (i--) {
+      const inst = this._detached[i];
+
+      inst.update(time);
+
+      if (inst.particles.length) {
+        flushed = true;
+      }
+
+      if (inst.particles.length === 0 && inst.activeChildren.size === 0) {
+        this._detached.splice(i, 1);
+        this.releaseEmitterInstance(inst);
+      }
+    }
+
+    if (flushed) {
+      this.dispatch(SYSTEM_UPDATE);
+    }
   }
 
   /**
@@ -205,6 +295,9 @@ export default class System {
     // Derive this emitter's deterministic seed from the system seed + its index
     // (stable across runs since emitters load in JSON order).
     emitter.reseed(this.seed, index);
+    // Assign tree-path node ids across the whole subtree (and enforce the depth
+    // cap) now that we know this emitter's root index.
+    emitter._assignNodeIds(`${index}`, 0, this.maxEmitterDepth);
 
     this.emitters.push(emitter);
     this.dispatch(EMITTER_ADDED, emitter);
@@ -295,6 +388,10 @@ export default class System {
           emitter.update(d);
           emitter.particles.length && this.dispatch(SYSTEM_UPDATE);
         }
+
+        // Advance detached child instances (dead parents) so their particles
+        // drain, then release the empty ones.
+        this._updateDetached(d);
       }
 
       this.dispatch(SYSTEM_UPDATE_AFTER);

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -5,7 +5,11 @@ import EventDispatcher, {
   SYSTEM_UPDATE_AFTER,
 } from '../events';
 
-import { DEFAULT_MAX_SUB_STEPS, DEFAULT_SYSTEM_DELTA } from './constants';
+import {
+  DEFAULT_MAX_EMITTER_INSTANCES,
+  DEFAULT_MAX_SUB_STEPS,
+  DEFAULT_SYSTEM_DELTA,
+} from './constants';
 import Emitter from '../emitter/Emitter';
 import { INTEGRATION_TYPE_EULER } from '../math/constants';
 import { randomSeed } from '../math/rng';
@@ -15,6 +19,7 @@ import fromJSON, { SystemJSON } from './fromJSON';
 import fromJSONAsync from './fromJSONAsync';
 import { CORE_TYPE_SYSTEM as type } from './types';
 import type BaseRenderer from '../renderer/BaseRenderer';
+import type Particle from './Particle';
 import type { Listener } from '../events/EventDispatcher';
 
 type ThreeApi = typeof import('three');
@@ -52,6 +57,17 @@ export default class System {
   fixedTimeStep: number;
   maxSubSteps: number;
   _accumulator: number;
+  // Emitter-instance pooling + cap (spec 01, Stage 1). Child emitter instances
+  // recycle through per-node free-lists, but the System owns the global live cap
+  // and instrumentation because child nodes aren't directly attached to it — the
+  // tree walk (Stage 2) drives spawn/release through here where the System is in
+  // scope. Counters are exposed for the sandbox HUD; the overflow warning fires
+  // once so the cap is never silently hit.
+  maxEmitterInstances: number;
+  _liveEmitterInstances: number;
+  _emitterPoolHits: number;
+  _emitterPoolMisses: number;
+  _warnedInstanceOverflow: boolean;
 
   constructor(
     preParticles: number = POOL_MAX,
@@ -70,6 +86,52 @@ export default class System {
     this.fixedTimeStep = DEFAULT_SYSTEM_DELTA;
     this.maxSubSteps = DEFAULT_MAX_SUB_STEPS;
     this._accumulator = 0;
+    this.maxEmitterInstances = DEFAULT_MAX_EMITTER_INSTANCES;
+    this._liveEmitterInstances = 0;
+    this._emitterPoolHits = 0;
+    this._emitterPoolMisses = 0;
+    this._warnedInstanceOverflow = false;
+  }
+
+  /**
+   * Acquires a child emitter instance of `node` bound to `parentParticle`,
+   * honouring the global live-instance cap. On overflow the newest spawn is
+   * dropped (the right default for FX) and a one-time warning is logged so the
+   * cap is never hit silently. Returns the instance, or null when dropped.
+   */
+  spawnEmitterInstance(
+    node: Emitter,
+    parentParticle: Particle
+  ): Emitter | null {
+    if (this._liveEmitterInstances >= this.maxEmitterInstances) {
+      if (!this._warnedInstanceOverflow) {
+        this._warnedInstanceOverflow = true;
+        // eslint-disable-next-line no-console
+        console.warn(
+          `three-nebula: maxEmitterInstances (${this.maxEmitterInstances}) reached; ` +
+            `dropping newest child emitter instances. Raise System.maxEmitterInstances if intended.`
+        );
+      }
+
+      return null;
+    }
+
+    const warm = node._freeInstances.length > 0;
+    const inst = node.acquireInstance(parentParticle);
+
+    warm ? this._emitterPoolHits++ : this._emitterPoolMisses++;
+    this._liveEmitterInstances++;
+
+    return inst;
+  }
+
+  /**
+   * Releases a child emitter instance back to its node's free-list and updates
+   * the live count. The caller guarantees the instance has drained its particles.
+   */
+  releaseEmitterInstance(inst: Emitter): void {
+    (inst._template as Emitter).releaseInstance(inst);
+    this._liveEmitterInstances--;
   }
 
   /**

--- a/src/core/System.ts
+++ b/src/core/System.ts
@@ -150,12 +150,18 @@ export default class System {
   }
 
   /**
-   * Detaches a child instance from its dead parent: it stops emitting but keeps
-   * updating so its already-emitted particles live out their lives, then is
-   * released once drained (see `_updateDetached`). This is the `detach` policy.
+   * Detaches a child instance from its (dead or absent) parent: it keeps updating
+   * so its already-emitted particles live out their lives, then is released once
+   * drained (see `_updateDetached`). Used by the `detach` orphan policy
+   * (`stopEmitting` true) and by `death`-trigger event bursts, which stay
+   * emitting so their one-shot burst fires after detachment (`stopEmitting`
+   * false — their own totalEmitTimes/life then bounds emission).
    */
-  _detachInstance(inst: Emitter): void {
-    inst.isEmitting = false;
+  _detachInstance(inst: Emitter, stopEmitting = true): void {
+    if (stopEmitting) {
+      inst.isEmitting = false;
+    }
+
     inst._parentParticle = null;
     this._detached.push(inst);
   }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -128,6 +128,17 @@ export const DEFAULT_SYSTEM_DELTA = 0.0167;
 export const DEFAULT_MAX_SUB_STEPS = 6;
 
 /**
+ * The default global cap on concurrently live child emitter instances (spec 01,
+ * Stage 1). Nested emitters multiply cardinality fast (100 parents × a child
+ * node = 100 live instances), so this bounds the blast radius. On overflow the
+ * newest instance is dropped — the right default for FX. Raise via
+ * `System.maxEmitterInstances` for genuinely large hierarchies.
+ *
+ * @type {number}
+ */
+export const DEFAULT_MAX_EMITTER_INSTANCES = 2000;
+
+/**
  * @desc The types of initializers supported by the System.fromJSON method.
  * @type {array<string>}
  */

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -139,6 +139,16 @@ export const DEFAULT_MAX_SUB_STEPS = 6;
 export const DEFAULT_MAX_EMITTER_INSTANCES = 2000;
 
 /**
+ * The default hard recursion limit on the emitter tree (spec 01, Stage 2). A
+ * self-triggering or accidentally deep hierarchy retains every ancestor instance
+ * until its last descendant dies, so an unbounded chain leaks until it exhausts
+ * memory. Trees deeper than this are rejected when added to a System.
+ *
+ * @type {number}
+ */
+export const DEFAULT_MAX_DEPTH = 4;
+
+/**
  * @desc The types of initializers supported by the System.fromJSON method.
  * @type {array<string>}
  */

--- a/src/core/fromJSON.ts
+++ b/src/core/fromJSON.ts
@@ -17,6 +17,7 @@ import type {
 import Rate from '../initializer/Rate';
 import type System from './System';
 import type Emitter from '../emitter/Emitter';
+import type { InheritConfig, OrphanPolicy } from '../emitter/Emitter';
 import type InitializerBase from '../initializer/Initializer';
 import type BehaviourBase from '../behaviour/Behaviour';
 
@@ -101,6 +102,12 @@ export interface EmitterJSON {
   totalEmitTimes?: number;
   life?: number;
   damping?: number;
+  // Emitter hierarchy (spec 01, Stage 2), all additive: `children` nests emitter
+  // templates (absent = a flat leaf emitter, i.e. today's schema); `inherit` and
+  // `orphanPolicy` only apply to a nested child.
+  children?: EmitterJSON[];
+  inherit?: Partial<InheritConfig>;
+  orphanPolicy?: OrphanPolicy;
 }
 
 export interface SystemJSON {
@@ -175,6 +182,57 @@ const makeBehaviours = (items: ItemJSON[]): BehaviourBase[] => {
 };
 
 /**
+ * Builds an emitter (and, recursively, its child templates) from JSON. Children
+ * are wired as `childNodes` rather than added to the System — only the root is
+ * added, which assigns the whole subtree's node ids and enforces the depth cap.
+ */
+const buildEmitter = (
+  data: EmitterJSON,
+  THREE: ThreeApi,
+  Emitter: EmitterConstructor
+): Emitter => {
+  const emitter = new Emitter();
+  const {
+    rate,
+    rotation,
+    initializers,
+    behaviours,
+    emitterBehaviours = [],
+    position,
+    totalEmitTimes = Infinity,
+    life = Infinity,
+    damping = DEFAULT_DAMPING,
+    children = [],
+    inherit,
+    orphanPolicy,
+  } = data;
+
+  emitter.damping = damping;
+  emitter
+    .setRate(makeRate(rate))
+    .setRotation(rotation)
+    .setInitializers(makeInitializers(initializers, THREE))
+    .setBehaviours(makeBehaviours(behaviours))
+    .setEmitterBehaviours(makeBehaviours(emitterBehaviours))
+    .setPosition(position)
+    .emit(totalEmitTimes, life);
+
+  if (inherit) {
+    emitter.inherit = { ...emitter.inherit, ...inherit };
+  }
+
+  if (orphanPolicy) {
+    emitter.orphanPolicy = orphanPolicy;
+  }
+
+  children.forEach(child =>
+    emitter.addChild(buildEmitter(child, THREE, Emitter))
+  );
+
+  return emitter;
+};
+
+/**
  * Creates a System instance from a JSON object.
  *
  * @deprecated Use fromJSONAsync instead.
@@ -195,32 +253,9 @@ export default (
   // set system.preParticles to the three namespace. Fixed to match the async path.
   const system = new System(preParticles, integrationType);
 
-  emitters.forEach(data => {
-    const emitter = new Emitter();
-    const {
-      rate,
-      rotation,
-      initializers,
-      behaviours,
-      emitterBehaviours = [],
-      position,
-      totalEmitTimes = Infinity,
-      life = Infinity,
-      damping = DEFAULT_DAMPING,
-    } = data;
-
-    emitter.damping = damping;
-    emitter
-      .setRate(makeRate(rate))
-      .setRotation(rotation)
-      .setInitializers(makeInitializers(initializers, THREE))
-      .setBehaviours(makeBehaviours(behaviours))
-      .setEmitterBehaviours(makeBehaviours(emitterBehaviours))
-      .setPosition(position)
-      .emit(totalEmitTimes, life);
-
-    system.addEmitter(emitter);
-  });
+  emitters.forEach(data =>
+    system.addEmitter(buildEmitter(data, THREE, Emitter))
+  );
 
   return system;
 };

--- a/src/core/fromJSON.ts
+++ b/src/core/fromJSON.ts
@@ -17,7 +17,11 @@ import type {
 import Rate from '../initializer/Rate';
 import type System from './System';
 import type Emitter from '../emitter/Emitter';
-import type { InheritConfig, OrphanPolicy } from '../emitter/Emitter';
+import type {
+  InheritConfig,
+  OrphanPolicy,
+  EmitterTrigger,
+} from '../emitter/Emitter';
 import type InitializerBase from '../initializer/Initializer';
 import type BehaviourBase from '../behaviour/Behaviour';
 
@@ -108,6 +112,9 @@ export interface EmitterJSON {
   children?: EmitterJSON[];
   inherit?: Partial<InheritConfig>;
   orphanPolicy?: OrphanPolicy;
+  // Stage 5: `spawn` (default) attaches this child at parent birth; `death`
+  // bursts it at parent death.
+  trigger?: EmitterTrigger;
 }
 
 export interface SystemJSON {
@@ -205,6 +212,7 @@ const buildEmitter = (
     children = [],
     inherit,
     orphanPolicy,
+    trigger,
   } = data;
 
   emitter.damping = damping;
@@ -223,6 +231,10 @@ const buildEmitter = (
 
   if (orphanPolicy) {
     emitter.orphanPolicy = orphanPolicy;
+  }
+
+  if (trigger) {
+    emitter.trigger = trigger;
   }
 
   children.forEach(child =>

--- a/src/core/fromJSONAsync.ts
+++ b/src/core/fromJSONAsync.ts
@@ -161,6 +161,7 @@ const buildEmitterAsync = (
     children = [],
     inherit,
     orphanPolicy,
+    trigger,
   } = data;
 
   emitter.damping = damping;
@@ -172,6 +173,10 @@ const buildEmitterAsync = (
 
   if (orphanPolicy) {
     emitter.orphanPolicy = orphanPolicy;
+  }
+
+  if (trigger) {
+    emitter.trigger = trigger;
   }
 
   return makeInitializers(initializers, THREE)

--- a/src/core/fromJSONAsync.ts
+++ b/src/core/fromJSONAsync.ts
@@ -135,79 +135,88 @@ const makeBehaviours = (items: ItemJSON[]): Promise<BehaviourBase[]> =>
     });
   });
 
+/**
+ * Builds one emitter (and, recursively, its child templates) from JSON, awaiting
+ * each node's async initializer/texture loads. Children are wired as `childNodes`
+ * via addChild; only the root is added to the System (which assigns node ids and
+ * enforces the depth cap). Mirrors the sync `buildEmitter`.
+ */
+const buildEmitterAsync = (
+  data: EmitterJSON,
+  Emitter: EmitterConstructor,
+  THREE: ThreeApi,
+  shouldAutoEmit: boolean | undefined
+): Promise<Emitter> => {
+  const emitter = new Emitter();
+  const {
+    rate,
+    rotation,
+    initializers,
+    behaviours,
+    emitterBehaviours = [],
+    position,
+    totalEmitTimes = Infinity,
+    life = Infinity,
+    damping = DEFAULT_DAMPING,
+    children = [],
+    inherit,
+    orphanPolicy,
+  } = data;
+
+  emitter.damping = damping;
+  emitter.setRate(makeRate(rate)).setRotation(rotation).setPosition(position);
+
+  if (inherit) {
+    emitter.inherit = { ...emitter.inherit, ...inherit };
+  }
+
+  if (orphanPolicy) {
+    emitter.orphanPolicy = orphanPolicy;
+  }
+
+  return makeInitializers(initializers, THREE)
+    .then(madeInitializers => {
+      emitter.setInitializers(madeInitializers);
+
+      return makeBehaviours(behaviours);
+    })
+    .then(madeBehaviours => {
+      emitter.setBehaviours(madeBehaviours);
+
+      return makeBehaviours(emitterBehaviours);
+    })
+    .then(madeEmitterBehaviours => {
+      emitter.setEmitterBehaviours(madeEmitterBehaviours);
+
+      // Build children in order (each may itself load textures asynchronously).
+      return Promise.all(
+        children.map(child =>
+          buildEmitterAsync(child, Emitter, THREE, shouldAutoEmit)
+        )
+      );
+    })
+    .then(childEmitters => {
+      childEmitters.forEach(child => emitter.addChild(child));
+
+      return shouldAutoEmit
+        ? emitter.emit(totalEmitTimes, life)
+        : emitter.setTotalEmitTimes(totalEmitTimes).setLife(life);
+    });
+};
+
 const makeEmitters = (
   emitters: EmitterJSON[],
   Emitter: EmitterConstructor,
   THREE: ThreeApi,
   shouldAutoEmit: boolean | undefined
 ): Promise<Emitter[]> =>
-  new Promise((resolve, reject) => {
-    if (!emitters.length) {
-      return resolve([]);
-    }
-
-    const numberOfEmitters = emitters.length;
-
-    if (!numberOfEmitters) {
-      return resolve([]);
-    }
-
-    // Each built emitter is written at its ORIGINAL index, and we resolve once every
-    // slot is filled — so system.emitters preserves the input order regardless of how
-    // the emitters' async initializer/texture loads interleave. (Previously emitters
-    // were pushed as they completed, i.e. in load-resolution order.)
-    const madeEmitters: Emitter[] = new Array(numberOfEmitters);
-    let madeCount = 0;
-
-    emitters.forEach((data, index) => {
-      const emitter = new Emitter();
-      const {
-        rate,
-        rotation,
-        initializers,
-        behaviours,
-        emitterBehaviours = [],
-        position,
-        totalEmitTimes = Infinity,
-        life = Infinity,
-        damping = DEFAULT_DAMPING,
-      } = data;
-
-      emitter.damping = damping;
-      emitter
-        .setRate(makeRate(rate))
-        .setRotation(rotation)
-        .setPosition(position);
-
-      makeInitializers(initializers, THREE)
-        .then(madeInitializers => {
-          emitter.setInitializers(madeInitializers);
-
-          return makeBehaviours(behaviours);
-        })
-        .then(madeBehaviours => {
-          emitter.setBehaviours(madeBehaviours);
-
-          return makeBehaviours(emitterBehaviours);
-        })
-        .then(madeEmitterBehaviours => {
-          emitter.setEmitterBehaviours(madeEmitterBehaviours);
-
-          return Promise.resolve(emitter);
-        })
-        .then(emitter => {
-          madeEmitters[index] = shouldAutoEmit
-            ? emitter.emit(totalEmitTimes, life)
-            : emitter.setTotalEmitTimes(totalEmitTimes).setLife(life);
-          madeCount += 1;
-
-          if (madeCount === numberOfEmitters) {
-            return resolve(madeEmitters);
-          }
-        })
-        .catch(reject);
-    });
-  });
+  // Promise.all preserves input order, so system.emitters stays in JSON order
+  // regardless of how the nested async texture loads interleave.
+  Promise.all(
+    emitters.map(data =>
+      buildEmitterAsync(data, Emitter, THREE, shouldAutoEmit)
+    )
+  );
 
 /**
  * Creates a System instance from a JSON object.

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -52,11 +52,20 @@ export interface InheritConfig {
 /** What becomes of a dead parent's already-emitted child particles. */
 export type OrphanPolicy = 'kill' | 'detach';
 
+/** True when a channel should be applied on this call (Stage 3). */
+const shouldInherit = (mode: InheritMode, atSpawn: boolean): boolean =>
+  mode === 'always' || (atSpawn && mode === 'onCreate');
+
 /**
- * Copies the parent particle's transform onto a child instance according to its
- * `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
- * per-frame call (atSpawn=false) only re-applies the continuous `always` mode.
- * Scale inheritance is deferred to Stage 3 (it needs a per-emitter scale offset).
+ * Reflects the parent particle's transform onto a child instance according to
+ * its `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
+ * per-frame call (atSpawn=false) only re-applies continuous `always` channels.
+ *
+ * Position and rotation copy directly onto the instance (which bindEmitter then
+ * adds to each emitted particle). Scale can't do the same — a Scale behaviour
+ * overwrites `particle.scale` every frame — so the parent's scale is captured
+ * here and baked into each child particle's `radius` at birth (see setupParticle),
+ * which behaviours leave alone.
  */
 const applyInheritance = (
   inst: Emitter,
@@ -65,18 +74,16 @@ const applyInheritance = (
 ): void => {
   const { inherit } = inst;
 
-  if (
-    inherit.position === 'always' ||
-    (atSpawn && inherit.position === 'onCreate')
-  ) {
+  if (shouldInherit(inherit.position, atSpawn)) {
     inst.position.copy(particle.position);
   }
 
-  if (
-    inherit.rotation === 'always' ||
-    (atSpawn && inherit.rotation === 'onCreate')
-  ) {
+  if (shouldInherit(inherit.rotation, atSpawn)) {
     inst.rotation.copy(particle.rotation);
+  }
+
+  if (shouldInherit(inherit.scale, atSpawn)) {
+    inst._inheritedScale = particle.scale;
   }
 };
 
@@ -120,6 +127,9 @@ export default class Emitter extends Particle {
   orphanPolicy: OrphanPolicy;
   _template: Emitter | null;
   _parentParticle: Particle | null;
+  // The parent particle's scale captured for `inherit.scale`, baked into each
+  // child particle's radius at birth. 1 when scale is not inherited.
+  _inheritedScale: number;
   _freeInstances: Emitter[];
   // Live child instances riding each of this emitter's still-alive particles,
   // keyed by the parent particle so they can be orphaned when it dies. On a live
@@ -143,6 +153,7 @@ export default class Emitter extends Particle {
     this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
     this._template = null;
     this._parentParticle = null;
+    this._inheritedScale = 1;
     this._freeInstances = [];
     this.activeChildren = new Map();
     this.particles = [];
@@ -245,6 +256,7 @@ export default class Emitter extends Particle {
     this.particles.length = 0;
     this.activeChildren.clear();
     this._parentParticle = null;
+    this._inheritedScale = 1;
     this.position.set(0, 0, 0);
     this.rotation.clear();
   }
@@ -742,6 +754,12 @@ export default class Emitter extends Particle {
     particle.emitterId = this.nodeId || null;
 
     InitializerUtil.initialize(this, particle, initializers);
+
+    // Bake inherited parent scale into radius (Scale behaviours overwrite
+    // `scale` each frame; radius they leave alone). 1 for non-inheriting emitters.
+    if (this._inheritedScale !== 1) {
+      particle.radius *= this._inheritedScale;
+    }
 
     particle.addBehaviours(behaviours);
     particle.parent = this;

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_INHERIT_ROTATION,
   DEFAULT_INHERIT_SCALE,
   DEFAULT_ORPHAN_POLICY,
+  DEFAULT_EMITTER_TRIGGER,
 } from './constants';
 import { DEFAULT_MAX_DEPTH } from '../core/constants';
 import EventDispatcher, {
@@ -51,6 +52,14 @@ export interface InheritConfig {
 
 /** What becomes of a dead parent's already-emitted child particles. */
 export type OrphanPolicy = 'kill' | 'detach';
+
+/**
+ * When a child emitter is instanced (spec 01, Stage 5). `spawn` is attachment —
+ * instanced at the parent particle's birth and riding it. `death` is an event —
+ * instanced at the parent particle's death, bursting once at that position and
+ * outliving the parent (fireworks). `collision` is reserved for later.
+ */
+export type EmitterTrigger = 'spawn' | 'death';
 
 /** True when a channel should be applied on this call (Stage 3). */
 const shouldInherit = (mode: InheritMode, atSpawn: boolean): boolean =>
@@ -125,6 +134,9 @@ export default class Emitter extends Particle {
   childNodes: Emitter[];
   inherit: InheritConfig;
   orphanPolicy: OrphanPolicy;
+  // Whether this (child) node is attached at parent birth (`spawn`) or burst at
+  // parent death (`death`). Meaningless on a top-level emitter.
+  trigger: EmitterTrigger;
   _template: Emitter | null;
   _parentParticle: Particle | null;
   // The parent particle's scale captured for `inherit.scale`, baked into each
@@ -151,6 +163,7 @@ export default class Emitter extends Particle {
       scale: DEFAULT_INHERIT_SCALE,
     };
     this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
+    this.trigger = DEFAULT_EMITTER_TRIGGER;
     this._template = null;
     this._parentParticle = null;
     this._inheritedScale = 1;
@@ -227,6 +240,7 @@ export default class Emitter extends Particle {
     inst.childNodes = this.childNodes;
     inst.inherit = this.inherit;
     inst.orphanPolicy = this.orphanPolicy;
+    inst.trigger = this.trigger;
     inst.damping = this.damping;
     inst.rate = new Rate(this.rate.numPan, this.rate.timePan);
     inst.totalEmitTimes = this.totalEmitTimes;
@@ -344,7 +358,15 @@ export default class Emitter extends Particle {
     const instances: Emitter[] = [];
 
     for (let i = 0; i < this.childNodes.length; i++) {
-      const inst = system.spawnEmitterInstance(this.childNodes[i], particle);
+      const node = this.childNodes[i];
+
+      // Only `spawn`-trigger children attach at birth; `death` children are held
+      // back and burst when the parent particle dies (see _triggerDeathChildren).
+      if (node.trigger !== 'spawn') {
+        continue;
+      }
+
+      const inst = system.spawnEmitterInstance(node, particle);
 
       if (!inst) {
         continue;
@@ -356,6 +378,35 @@ export default class Emitter extends Particle {
 
     if (instances.length) {
       this.activeChildren.set(particle, instances);
+    }
+  }
+
+  /**
+   * Bursts every `death`-trigger child node at a particle that has just died: the
+   * instance is placed at the death position and released as a free-running,
+   * still-emitting detached instance, so its one-shot burst outlives the parent.
+   * Runs before the particle is reset (its position is still valid).
+   */
+  _triggerDeathChildren(particle: Particle): void {
+    const system = this.system as System;
+
+    for (let i = 0; i < this.childNodes.length; i++) {
+      const node = this.childNodes[i];
+
+      if (node.trigger !== 'death') {
+        continue;
+      }
+
+      const inst = system.spawnEmitterInstance(node, particle);
+
+      if (!inst) {
+        continue;
+      }
+
+      // Snapshot the death location; there is no parent to ride. Detach while
+      // keeping it emitting so its burst fires, then it drains and releases.
+      inst.position.copy(particle.position);
+      system._detachInstance(inst, false);
     }
   }
 
@@ -799,8 +850,12 @@ export default class Emitter extends Particle {
       const particle = this.particles[i];
 
       if (particle.dead) {
-        // Detach or kill any child instances riding this particle before it is
-        // reset and returned to the pool (the map is keyed on the particle).
+        // Before the particle is reset (its position is still valid): burst any
+        // `death`-trigger children at the death spot, then detach/kill any
+        // `spawn` children riding it (the map is keyed on the particle).
+        if (this.childNodes.length) {
+          this._triggerDeathChildren(particle);
+        }
         if (this.activeChildren.size) {
           this._orphanChildrenOf(particle);
         }

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -4,7 +4,12 @@ import {
   DEFAULT_DAMPING,
   DEFAULT_EMITTER_INDEX,
   DEFAULT_EMITTER_RATE,
+  DEFAULT_INHERIT_POSITION,
+  DEFAULT_INHERIT_ROTATION,
+  DEFAULT_INHERIT_SCALE,
+  DEFAULT_ORPHAN_POLICY,
 } from './constants';
+import { DEFAULT_MAX_DEPTH } from '../core/constants';
 import EventDispatcher, {
   EMITTER_DEAD,
   PARTICLE_CREATED,
@@ -30,6 +35,50 @@ interface Vector3Props {
   y?: number;
   z?: number;
 }
+
+/**
+ * How a child emitter's transform relates to its parent particle, per channel:
+ * `always` tracks it every frame (trails, attached FX), `onCreate` snapshots it
+ * once at spawn then runs free (ribbons, debris), `none` ignores it (system space).
+ */
+export type InheritMode = 'always' | 'onCreate' | 'none';
+
+export interface InheritConfig {
+  position: InheritMode;
+  rotation: InheritMode;
+  scale: InheritMode;
+}
+
+/** What becomes of a dead parent's already-emitted child particles. */
+export type OrphanPolicy = 'kill' | 'detach';
+
+/**
+ * Copies the parent particle's transform onto a child instance according to its
+ * `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
+ * per-frame call (atSpawn=false) only re-applies the continuous `always` mode.
+ * Scale inheritance is deferred to Stage 3 (it needs a per-emitter scale offset).
+ */
+const applyInheritance = (
+  inst: Emitter,
+  particle: Particle,
+  atSpawn: boolean
+): void => {
+  const { inherit } = inst;
+
+  if (
+    inherit.position === 'always' ||
+    (atSpawn && inherit.position === 'onCreate')
+  ) {
+    inst.position.copy(particle.position);
+  }
+
+  if (
+    inherit.rotation === 'always' ||
+    (atSpawn && inherit.rotation === 'onCreate')
+  ) {
+    inst.rotation.copy(particle.rotation);
+  }
+};
 
 /**
  * Emitters are the System engine's particle factories. They cause particles to
@@ -67,9 +116,15 @@ export default class Emitter extends Particle {
   // live particles rather than cumulative spawns.
   nodeId: string;
   childNodes: Emitter[];
+  inherit: InheritConfig;
+  orphanPolicy: OrphanPolicy;
   _template: Emitter | null;
   _parentParticle: Particle | null;
   _freeInstances: Emitter[];
+  // Live child instances riding each of this emitter's still-alive particles,
+  // keyed by the parent particle so they can be orphaned when it dies. On a live
+  // instance this holds its grandchildren; on a template it stays empty.
+  activeChildren: Map<Particle, Emitter[]>;
 
   constructor(properties?: Record<string, unknown>) {
     super(properties);
@@ -80,9 +135,16 @@ export default class Emitter extends Particle {
     this._spawnCount = 0;
     this.nodeId = '';
     this.childNodes = [];
+    this.inherit = {
+      position: DEFAULT_INHERIT_POSITION,
+      rotation: DEFAULT_INHERIT_ROTATION,
+      scale: DEFAULT_INHERIT_SCALE,
+    };
+    this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
     this._template = null;
     this._parentParticle = null;
     this._freeInstances = [];
+    this.activeChildren = new Map();
     this.particles = [];
     this.initializers = [];
     this.behaviours = [];
@@ -152,6 +214,8 @@ export default class Emitter extends Particle {
     inst.behaviours = this.behaviours;
     inst.emitterBehaviours = this.emitterBehaviours;
     inst.childNodes = this.childNodes;
+    inst.inherit = this.inherit;
+    inst.orphanPolicy = this.orphanPolicy;
     inst.damping = this.damping;
     inst.rate = new Rate(this.rate.numPan, this.rate.timePan);
     inst.totalEmitTimes = this.totalEmitTimes;
@@ -179,6 +243,7 @@ export default class Emitter extends Particle {
     this._spawnCount = 0;
     this.isEmitting = false;
     this.particles.length = 0;
+    this.activeChildren.clear();
     this._parentParticle = null;
     this.position.set(0, 0, 0);
     this.rotation.clear();
@@ -197,6 +262,10 @@ export default class Emitter extends Particle {
     inst._resetInstanceState();
     inst._parentParticle = parentParticle;
     inst.reseedFromParent(this.nodeId, parentParticle.id);
+    // Re-draw the emission interval from the instance's own seeded stream — the
+    // fresh Rate built in _createInstance seeded its first interval off
+    // Math.random, which would make child timing non-deterministic.
+    inst.rate.resetInterval(inst.rng);
     inst.isEmitting = true;
 
     return inst;
@@ -210,6 +279,117 @@ export default class Emitter extends Particle {
   releaseInstance(inst: Emitter): void {
     inst.isEmitting = false;
     this._freeInstances.push(inst);
+  }
+
+  /**
+   * Assigns this node's tree-path id and recurses into its children, so the whole
+   * subtree gets stable addresses (e.g. "0", "0/children/1"). Called by
+   * System.addEmitter with the emitter's array index as the root path. Enforces
+   * the hard depth cap here — the single choke point both the JSON and code paths
+   * flow through — throwing on an over-deep tree rather than leaking at runtime.
+   */
+  _assignNodeIds(
+    nodeId: string,
+    depth = 0,
+    maxDepth: number = DEFAULT_MAX_DEPTH
+  ): void {
+    if (depth > maxDepth) {
+      throw new Error(
+        `three-nebula: emitter hierarchy exceeds maxDepth (${maxDepth}) at "${nodeId}"`
+      );
+    }
+
+    this.nodeId = nodeId;
+
+    for (let i = 0; i < this.childNodes.length; i++) {
+      this.childNodes[i]._assignNodeIds(
+        `${nodeId}/children/${i}`,
+        depth + 1,
+        maxDepth
+      );
+    }
+  }
+
+  /**
+   * Nests a child emitter template under this one. The child is instanced once
+   * per particle this emitter spawns. Node ids are (re)assigned when the root is
+   * added to a System, so children may be attached in any order beforehand.
+   */
+  addChild(child: Emitter): this {
+    this.childNodes.push(child);
+
+    return this;
+  }
+
+  /**
+   * Spawns a child instance of every child node, bound to a just-created parent
+   * particle, and snapshots the parent transform for `onCreate` inheritance. The
+   * System owns the acquire (cap + accounting); a null return means the cap was
+   * hit and this child is dropped.
+   */
+  _spawnChildrenFor(particle: Particle): void {
+    const system = this.system as System;
+    const instances: Emitter[] = [];
+
+    for (let i = 0; i < this.childNodes.length; i++) {
+      const inst = system.spawnEmitterInstance(this.childNodes[i], particle);
+
+      if (!inst) {
+        continue;
+      }
+
+      applyInheritance(inst, particle, true);
+      instances.push(inst);
+    }
+
+    if (instances.length) {
+      this.activeChildren.set(particle, instances);
+    }
+  }
+
+  /**
+   * Handles the child instances riding a particle that has just died: each is
+   * either detached (its particles live on, per `detach`) or killed with it.
+   * Runs before the particle is reset so the mapping key is still valid.
+   */
+  _orphanChildrenOf(particle: Particle): void {
+    const instances = this.activeChildren.get(particle);
+
+    if (!instances) {
+      return;
+    }
+
+    const system = this.system as System;
+
+    for (let i = 0; i < instances.length; i++) {
+      const inst = instances[i];
+
+      inst.orphanPolicy === 'kill'
+        ? system._killInstance(inst)
+        : system._detachInstance(inst);
+    }
+
+    this.activeChildren.delete(particle);
+  }
+
+  /**
+   * Advances the child instances riding each still-live particle, after this
+   * emitter's own particles have moved this frame (topological order: a parent
+   * resolves before its children read its transform). Recurses via inst.update.
+   */
+  _updateChildInstances(time: number): void {
+    if (!this.activeChildren.size) {
+      return;
+    }
+
+    this.activeChildren.forEach((instances, particle) => {
+      for (let i = 0; i < instances.length; i++) {
+        const inst = instances[i];
+
+        applyInheritance(inst, particle, false);
+        inst.update(time);
+      }
+    });
   }
 
   /**
@@ -534,6 +714,11 @@ export default class Emitter extends Particle {
     this.system && this.system.dispatch(PARTICLE_CREATED, particle);
     this.bindEmitterEvent && this.dispatch(PARTICLE_CREATED, particle);
 
+    // Instance a child emitter per child node, riding this new particle.
+    if (this.childNodes.length && this.system) {
+      this._spawnChildrenFor(particle);
+    }
+
     return particle;
   }
 
@@ -592,6 +777,11 @@ export default class Emitter extends Particle {
       const particle = this.particles[i];
 
       if (particle.dead) {
+        // Detach or kill any child instances riding this particle before it is
+        // reset and returned to the pool (the map is keyed on the particle).
+        if (this.activeChildren.size) {
+          this._orphanChildrenOf(particle);
+        }
         this.system && this.system.dispatch(PARTICLE_DEAD, particle);
         this.bindEmitterEvent && this.dispatch(PARTICLE_DEAD, particle);
         // faithful to the pre-migration crash if the emitter is detached.
@@ -604,6 +794,9 @@ export default class Emitter extends Particle {
     }
 
     this.updateEmitterBehaviours(time);
+
+    // Children resolve last, after this emitter's particles have advanced.
+    this._updateChildInstances(time);
   }
 
   /**

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -57,6 +57,19 @@ export default class Emitter extends Particle {
   // Monotonic spawn counter — never reused, survives pooling — so each particle
   // gets a stable, unique index for its ID and seed.
   _spawnCount: number;
+  // Emitter hierarchy (spec 01, Stage 1). `nodeId` is this emitter's tree-path
+  // address (e.g. "0/children/0"), assigned when loaded from a hierarchy; it is
+  // the key child seeds derive from and the stamp put on emitted particles.
+  // `childNodes` are authored child templates, each instanced once per parent
+  // particle. A live instance sets `_template` (the node it was cloned from) and
+  // `_parentParticle` (the particle it rides); `_freeInstances` is a template's
+  // own free-list of dormant instances, so recycling bounds instance count by
+  // live particles rather than cumulative spawns.
+  nodeId: string;
+  childNodes: Emitter[];
+  _template: Emitter | null;
+  _parentParticle: Particle | null;
+  _freeInstances: Emitter[];
 
   constructor(properties?: Record<string, unknown>) {
     super(properties);
@@ -65,6 +78,11 @@ export default class Emitter extends Particle {
     this.seed = randomSeed();
     this.rng = mulberry32(this.seed);
     this._spawnCount = 0;
+    this.nodeId = '';
+    this.childNodes = [];
+    this._template = null;
+    this._parentParticle = null;
+    this._freeInstances = [];
     this.particles = [];
     this.initializers = [];
     this.behaviours = [];
@@ -102,6 +120,96 @@ export default class Emitter extends Particle {
     this._spawnCount = 0;
 
     return this;
+  }
+
+  /**
+   * Derives a child instance's seed from its node's tree-path address and the
+   * parent particle's (stable, deterministic) id, so a given parent always
+   * produces the same child stream. Mirrors `reseed` but keyed on identity
+   * rather than array index (a child instance has no fixed index).
+   */
+  reseedFromParent(nodeId: string, parentParticleId: string): this {
+    this.seed = hashSeed(nodeId, parentParticleId);
+    this.rng = mulberry32(this.seed);
+    this._spawnCount = 0;
+
+    return this;
+  }
+
+  /**
+   * Cold path: builds a fresh instance of this node. Config (initializers,
+   * behaviours, child templates) is shared by reference — it is read-only during
+   * simulation — while all mutable runtime state is per-instance. The instance
+   * gets its own Rate over the template's immutable Spans so interval counters
+   * don't collide across the many instances of one node.
+   */
+  _createInstance(): Emitter {
+    const inst = new Emitter();
+
+    inst._template = this;
+    inst.nodeId = this.nodeId;
+    inst.initializers = this.initializers;
+    inst.behaviours = this.behaviours;
+    inst.emitterBehaviours = this.emitterBehaviours;
+    inst.childNodes = this.childNodes;
+    inst.damping = this.damping;
+    inst.rate = new Rate(this.rate.numPan, this.rate.timePan);
+    inst.totalEmitTimes = this.totalEmitTimes;
+    inst.life = this.life;
+
+    return inst;
+  }
+
+  /**
+   * Clears an instance's runtime state so a pooled instance is indistinguishable
+   * from a cold one. Deliberately does NOT touch the shared config arrays (that
+   * would mutate the template every other instance reads) — only per-instance
+   * mutable fields. `totalEmitTimes`/`life` are restored from the template since
+   * `generate` decrements them as the instance runs.
+   */
+  _resetInstanceState(): void {
+    const template = this._template as Emitter;
+
+    this.age = 0;
+    this.dead = false;
+    this.energy = 1;
+    this.currentEmitTime = 0;
+    this.totalEmitTimes = template.totalEmitTimes;
+    this.life = template.life;
+    this._spawnCount = 0;
+    this.isEmitting = false;
+    this.particles.length = 0;
+    this._parentParticle = null;
+    this.position.set(0, 0, 0);
+    this.rotation.clear();
+  }
+
+  /**
+   * Warm-or-cold acquire of an instance of this node bound to `parentParticle`.
+   * Pops the free-list when possible (no allocation on the warm path), otherwise
+   * builds one. The instance is reseeded from the parent's id so its stream is
+   * deterministic. Call on the template node; the returned instance carries a
+   * `_template` back-reference for release.
+   */
+  acquireInstance(parentParticle: Particle): Emitter {
+    const inst = this._freeInstances.pop() ?? this._createInstance();
+
+    inst._resetInstanceState();
+    inst._parentParticle = parentParticle;
+    inst.reseedFromParent(this.nodeId, parentParticle.id);
+    inst.isEmitting = true;
+
+    return inst;
+  }
+
+  /**
+   * Returns an instance to this node's free-list for reuse. Callers must ensure
+   * the instance has no live particles first (the System's release path only
+   * releases once a detached instance has drained).
+   */
+  releaseInstance(inst: Emitter): void {
+    inst.isEmitting = false;
+    this._freeInstances.push(inst);
   }
 
   /**
@@ -443,6 +551,10 @@ export default class Emitter extends Particle {
 
     particle.id = `particle-${this.seed}-${spawnIndex}`;
     particle.rng = mulberry32(hashSeed(this.seed, spawnIndex));
+    // Stamp the spawning emitter's node id (null for a flat top-level emitter,
+    // whose nodeId is still ''); lights up automatically once hierarchy loading
+    // assigns tree-path ids.
+    particle.emitterId = this.nodeId || null;
 
     InitializerUtil.initialize(this, particle, initializers);
 

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -752,6 +752,10 @@ export default class Emitter extends Particle {
     // whose nodeId is still ''); lights up automatically once hierarchy loading
     // assigns tree-path ids.
     particle.emitterId = this.nodeId || null;
+    // Per-instance grouping key + spine order for the RibbonRenderer (Stage 4).
+    // The seed is unique per live emitter, so each child trail is its own strip.
+    particle.emitterInstanceId = `${this.seed}`;
+    particle.spawnIndex = spawnIndex;
 
     InitializerUtil.initialize(this, particle, initializers);
 

--- a/src/emitter/constants.ts
+++ b/src/emitter/constants.ts
@@ -5,3 +5,15 @@ export const DEFAULT_BIND_EMITTER = true;
 export const DEFAULT_EMITTER_RATE = new Rate(1, 0.1);
 export const DEFAULT_BIND_EMITTER_EVENT = false;
 export const DEFAULT_EMITTER_INDEX = undefined;
+
+// Emitter hierarchy (spec 01, Stage 2). A child emitter's transform tracks its
+// parent particle per channel: position follows by default (trails/attached FX),
+// rotation and scale are left in system space unless asked for.
+export const DEFAULT_INHERIT_POSITION = 'always';
+export const DEFAULT_INHERIT_ROTATION = 'none';
+export const DEFAULT_INHERIT_SCALE = 'none';
+
+// What happens to a child instance's already-emitted particles when its parent
+// particle dies. `detach` lets them live out their lives (a spark's smoke should
+// outlive the spark); `kill` takes them with it.
+export const DEFAULT_ORPHAN_POLICY = 'detach';

--- a/src/emitter/constants.ts
+++ b/src/emitter/constants.ts
@@ -17,3 +17,9 @@ export const DEFAULT_INHERIT_SCALE = 'none';
 // particle dies. `detach` lets them live out their lives (a spark's smoke should
 // outlive the spark); `kill` takes them with it.
 export const DEFAULT_ORPHAN_POLICY = 'detach';
+
+// When a child emitter is instanced (spec 01, Stage 5). `spawn` (default) is
+// attachment — instanced at parent-particle birth, rides it (Stages 2–3).
+// `death` is an event — instanced at parent-particle death, bursts at the death
+// position and outlives the parent (fireworks).
+export const DEFAULT_EMITTER_TRIGGER = 'spawn';

--- a/src/renderer/RibbonRenderer.ts
+++ b/src/renderer/RibbonRenderer.ts
@@ -1,0 +1,364 @@
+import BaseRenderer from './BaseRenderer';
+import { RENDERER_TYPE_RIBBON as type } from './types';
+import type Particle from '../core/Particle';
+import type System from '../core/System';
+import type {
+  BufferGeometry,
+  Camera,
+  Mesh,
+  Object3D,
+  Texture,
+  Vector3,
+} from 'three';
+
+type ThreeApi = typeof import('three');
+
+type BlendingMode =
+  | 'AdditiveBlending'
+  | 'NormalBlending'
+  | 'NoBlending'
+  | 'SubtractiveBlending'
+  | 'MultiplyBlending';
+
+interface RibbonRendererOptions {
+  // The camera the ribbons should face. Without it, ribbons orient against a
+  // fixed world-up instead (fine for a mostly side-on view).
+  camera?: Camera;
+  // Full ribbon width in world units, multiplied per-spine-point by the
+  // particle's scale so a Scale behaviour tapers the strip.
+  width: number;
+  blending: BlendingMode;
+  // Optional strip texture. UVs run along the ribbon per `uv` mode.
+  texture?: Texture;
+  // 'stretch' maps U 0→1 across the whole ribbon; 'tile' repeats U per segment.
+  uv: 'stretch' | 'tile';
+  depthTest: boolean;
+  depthWrite: boolean;
+}
+
+const DEFAULT_OPTIONS: RibbonRendererOptions = {
+  width: 20,
+  blending: 'AdditiveBlending',
+  uv: 'stretch',
+  depthTest: true,
+  depthWrite: false,
+};
+
+// Spine order within one instance is spawn order — the strip runs oldest→newest.
+export const bySpawnIndex = (a: Particle, b: Particle): number =>
+  a.spawnIndex - b.spawnIndex;
+
+/**
+ * Triangle indices for a ribbon of `pointCount` spine points. Each point owns two
+ * vertices (left = 2i, right = 2i+1); each segment is two triangles. Pure so it
+ * can be unit tested without THREE.
+ */
+export const ribbonIndices = (pointCount: number): number[] => {
+  const indices: number[] = [];
+
+  for (let i = 0; i < pointCount - 1; i++) {
+    const l0 = 2 * i;
+    const r0 = 2 * i + 1;
+    const l1 = 2 * i + 2;
+    const r1 = 2 * i + 3;
+
+    indices.push(l0, l1, r0, r0, l1, r1);
+  }
+
+  return indices;
+};
+
+interface Ribbon {
+  mesh: Mesh;
+  geometry: BufferGeometry;
+  positions: Float32Array;
+  colors: Float32Array;
+  uvs: Float32Array;
+  capacity: number; // spine points the buffers can hold
+}
+
+/**
+ * Renders each emitter instance's particles as a single continuous, camera-facing
+ * strip — the particles are the spine, in spawn order (spec 01, Stage 4). One
+ * strip per `emitterInstanceId`, so every child-emitter trail is its own ribbon.
+ *
+ * Rebuilt each `onSystemUpdate` from the live particles the renderer is tracking;
+ * width tapers with particle scale, colour/alpha come from the particle. Handles
+ * the degenerate cases: a group of fewer than two points is hidden, and
+ * zero-length segments reuse the previous orientation rather than emit NaNs.
+ */
+export default class RibbonRenderer extends BaseRenderer {
+  three: ThreeApi;
+  container: Object3D;
+  options: RibbonRendererOptions;
+  // Live particles grouped by the instance that emitted them.
+  _groups: Map<string, Particle[]>;
+  _ribbons: Map<string, Ribbon>;
+  // Reused scratch vectors so the per-frame rebuild allocates nothing.
+  _camPos: Vector3;
+  _prev: Vector3;
+  _next: Vector3;
+  _tangent: Vector3;
+  _view: Vector3;
+  _side: Vector3;
+  _lastSide: Vector3;
+  _up: Vector3;
+
+  constructor(
+    container: Object3D,
+    THREE: ThreeApi,
+    options: Partial<RibbonRendererOptions> = {}
+  ) {
+    super(type);
+
+    this.three = THREE;
+    this.container = container;
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this._groups = new Map();
+    this._ribbons = new Map();
+    this._camPos = new THREE.Vector3();
+    this._prev = new THREE.Vector3();
+    this._next = new THREE.Vector3();
+    this._tangent = new THREE.Vector3();
+    this._view = new THREE.Vector3();
+    this._side = new THREE.Vector3();
+    this._lastSide = new THREE.Vector3(1, 0, 0);
+    this._up = new THREE.Vector3(0, 1, 0);
+  }
+
+  // Group key: the emitting instance, falling back to the node id or a shared
+  // bucket so the renderer also works on a plain (non-hierarchy) emitter.
+  _keyOf(particle: Particle): string {
+    return particle.emitterInstanceId || particle.emitterId || 'ribbon';
+  }
+
+  onParticleCreated(particle: Particle): void {
+    const key = this._keyOf(particle);
+    const group = this._groups.get(key);
+
+    if (group) {
+      group.push(particle);
+    } else {
+      this._groups.set(key, [particle]);
+    }
+  }
+
+  onParticleUpdate(): void {
+    // Positions are read from the live particles at rebuild time; nothing to do.
+  }
+
+  onParticleDead(particle: Particle): void {
+    const key = this._keyOf(particle);
+    const group = this._groups.get(key);
+
+    if (!group) {
+      return;
+    }
+
+    const index = group.indexOf(particle);
+
+    if (index > -1) {
+      group.splice(index, 1);
+    }
+
+    if (group.length === 0) {
+      this._groups.delete(key);
+      this._disposeRibbon(key);
+    }
+  }
+
+  onSystemUpdate(): void {
+    this._groups.forEach((group, key) => this._rebuild(key, group));
+  }
+
+  _rebuild(key: string, group: Particle[]): void {
+    const ribbon = this._ensureRibbon(key, group.length);
+
+    if (group.length < 2) {
+      ribbon.mesh.visible = false;
+
+      return;
+    }
+
+    ribbon.mesh.visible = true;
+    group.sort(bySpawnIndex);
+
+    const { width, uv, camera } = this.options;
+    const n = group.length;
+    const { positions, colors, uvs } = ribbon;
+
+    if (camera) {
+      camera.getWorldPosition(this._camPos);
+    }
+
+    for (let i = 0; i < n; i++) {
+      const particle = group[i];
+      const point = particle.position as unknown as Vector3;
+
+      // Tangent by central difference (forward/backward at the ends).
+      this._prev.copy(
+        i > 0 ? (group[i - 1].position as unknown as Vector3) : point
+      );
+      this._next.copy(
+        i < n - 1 ? (group[i + 1].position as unknown as Vector3) : point
+      );
+      this._tangent.subVectors(this._next, this._prev);
+
+      // Side = tangent × view, camera-facing when a camera is set.
+      if (camera) {
+        this._view.subVectors(this._camPos, point).normalize();
+      } else {
+        this._view.copy(this._up);
+      }
+
+      this._side.crossVectors(this._tangent, this._view);
+
+      if (this._side.lengthSq() < 1e-12) {
+        // Coincident points or tangent parallel to view — keep the last good
+        // orientation instead of emitting a zero-length (NaN-normal) segment.
+        this._side.copy(this._lastSide);
+      } else {
+        this._side.normalize();
+
+        // Keep the strip from flipping its edges (a bowtie/twist) where the
+        // cross product changes sign as the spine curves relative to the camera:
+        // align each side with the previous one. `_lastSide` is re-established at
+        // point 0 of every rebuild, so continuity is per-spine, not cross-frame.
+        if (i > 0 && this._side.dot(this._lastSide) < 0) {
+          this._side.negate();
+        }
+      }
+
+      this._lastSide.copy(this._side);
+
+      const half = 0.5 * width * particle.scale;
+      const lx = point.x + this._side.x * half;
+      const ly = point.y + this._side.y * half;
+      const lz = point.z + this._side.z * half;
+      const rx = point.x - this._side.x * half;
+      const ry = point.y - this._side.y * half;
+      const rz = point.z - this._side.z * half;
+
+      const vl = i * 6;
+
+      positions[vl] = lx;
+      positions[vl + 1] = ly;
+      positions[vl + 2] = lz;
+      positions[vl + 3] = rx;
+      positions[vl + 4] = ry;
+      positions[vl + 5] = rz;
+
+      const { r, g, b } = particle.color;
+      const a = particle.alpha;
+      const cl = i * 8;
+
+      colors[cl] = r;
+      colors[cl + 1] = g;
+      colors[cl + 2] = b;
+      colors[cl + 3] = a;
+      colors[cl + 4] = r;
+      colors[cl + 5] = g;
+      colors[cl + 6] = b;
+      colors[cl + 7] = a;
+
+      const u = uv === 'tile' ? i : i / (n - 1);
+      const ul = i * 4;
+
+      uvs[ul] = u;
+      uvs[ul + 1] = 1;
+      uvs[ul + 2] = u;
+      uvs[ul + 3] = 0;
+    }
+
+    const { geometry } = ribbon;
+
+    (geometry.attributes.position.array as Float32Array).set(
+      positions.subarray(0, n * 6)
+    );
+    (geometry.attributes.color.array as Float32Array).set(
+      colors.subarray(0, n * 8)
+    );
+    (geometry.attributes.uv.array as Float32Array).set(uvs.subarray(0, n * 4));
+
+    geometry.attributes.position.needsUpdate = true;
+    geometry.attributes.color.needsUpdate = true;
+    geometry.attributes.uv.needsUpdate = true;
+    geometry.setDrawRange(0, (n - 1) * 6);
+  }
+
+  // Returns the ribbon for `key`, (re)allocating its buffers to hold at least
+  // `points` spine points. Grows only — buffers are never shrunk.
+  _ensureRibbon(key: string, points: number): Ribbon {
+    const THREE = this.three;
+    let ribbon = this._ribbons.get(key);
+    const capacity = Math.max(points, 2);
+
+    if (ribbon && ribbon.capacity >= capacity) {
+      return ribbon;
+    }
+
+    // (Re)allocate buffers sized to the new capacity, preserving the mesh.
+    const positions = new Float32Array(capacity * 6);
+    const colors = new Float32Array(capacity * 8);
+    const uvs = new Float32Array(capacity * 4);
+    const indices = ribbonIndices(capacity);
+
+    let geometry: BufferGeometry;
+    let mesh: Mesh;
+
+    if (ribbon) {
+      geometry = ribbon.geometry;
+      mesh = ribbon.mesh;
+    } else {
+      geometry = new THREE.BufferGeometry();
+      const { blending, texture, depthTest, depthWrite } = this.options;
+      const material = new THREE.MeshBasicMaterial({
+        vertexColors: true,
+        transparent: true,
+        side: THREE.DoubleSide,
+        blending: THREE[blending],
+        map: texture || null,
+        depthTest,
+        depthWrite,
+      });
+
+      mesh = new THREE.Mesh(geometry, material);
+      mesh.frustumCulled = false;
+      this.container.add(mesh);
+    }
+
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 4));
+    geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+    geometry.setIndex(indices);
+
+    ribbon = { mesh, geometry, positions, colors, uvs, capacity };
+    this._ribbons.set(key, ribbon);
+
+    return ribbon;
+  }
+
+  _disposeRibbon(key: string): void {
+    const ribbon = this._ribbons.get(key);
+
+    if (!ribbon) {
+      return;
+    }
+
+    this.container.remove(ribbon.mesh);
+    ribbon.geometry.dispose();
+    (ribbon.mesh.material as { dispose: () => void }).dispose();
+    this._ribbons.delete(key);
+  }
+
+  onSystemUpdateAfter?(): void {}
+
+  remove(_system?: System): void {
+    this._ribbons.forEach((_ribbon, key) => this._disposeRibbon(key));
+    this._groups.clear();
+  }
+
+  destroy(): void {
+    this.remove();
+  }
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,5 @@
 export { default as CustomRenderer } from './CustomRenderer';
 export { default as MeshRenderer } from './MeshRenderer';
+export { default as RibbonRenderer } from './RibbonRenderer';
 export { default as SpriteRenderer } from './SpriteRenderer';
 export { default as GPURenderer } from './GPURenderer';

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -2,6 +2,7 @@ export const RENDERER_TYPE_BASE = 'BaseRenderer';
 export const RENDERER_TYPE_CUSTOM = 'CustomRenderer';
 export const RENDERER_TYPE_SPRITE = 'SpriteRenderer';
 export const RENDERER_TYPE_MESH = 'MeshRenderer';
+export const RENDERER_TYPE_RIBBON = 'RibbonRenderer';
 export const RENDERER_TYPE_GPU = 'GPURenderer';
 export const RENDERER_TYPE_GPU_MOBILE = 'MobileGPURenderer';
 export const RENDERER_TYPE_GPU_DESKTOP = 'DesktopGPURenderer';

--- a/test/core/fromJSON.spec.js
+++ b/test/core/fromJSON.spec.js
@@ -143,4 +143,71 @@ describe('fromJSON', () => {
       'The zone type MrDoob is invalid or not yet supported'
     );
   });
+
+  describe('emitter hierarchy (children)', () => {
+    const withChild = (childProps = {}) => ({
+      emitters: [
+        {
+          rate: { particlesMin: 1, particlesMax: 1 },
+          initializers: [],
+          behaviours: [],
+          children: [
+            {
+              rate: { particlesMin: 1, particlesMax: 1 },
+              initializers: [],
+              behaviours: [],
+              ...childProps,
+            },
+          ],
+        },
+      ],
+    });
+
+    it('nests child emitters as childNodes rather than top-level emitters', () => {
+      const system = Particles.fromJSON(withChild(), THREE);
+
+      assert.lengthOf(system.emitters, 1, 'child is not a sibling');
+      assert.lengthOf(system.emitters[0].childNodes, 1);
+    });
+
+    it('assigns tree-path node ids across the subtree', () => {
+      const system = Particles.fromJSON(withChild(), THREE);
+
+      assert.equal(system.emitters[0].nodeId, '0');
+      assert.equal(system.emitters[0].childNodes[0].nodeId, '0/children/0');
+    });
+
+    it('parses inherit (merged over defaults) and orphanPolicy', () => {
+      const system = Particles.fromJSON(
+        withChild({
+          inherit: { position: 'onCreate' },
+          orphanPolicy: 'kill',
+        }),
+        THREE
+      );
+      const child = system.emitters[0].childNodes[0];
+
+      assert.equal(child.inherit.position, 'onCreate', 'overridden');
+      assert.equal(child.inherit.rotation, 'none', 'default preserved');
+      assert.equal(child.orphanPolicy, 'kill');
+    });
+
+    it('defaults inherit and orphanPolicy when absent', () => {
+      const child = Particles.fromJSON(withChild(), THREE).emitters[0]
+        .childNodes[0];
+
+      assert.deepEqual(child.inherit, {
+        position: 'always',
+        rotation: 'none',
+        scale: 'none',
+      });
+      assert.equal(child.orphanPolicy, 'detach');
+    });
+
+    it('leaves flat (childless) emitters unchanged', () => {
+      const system = Particles.fromJSON(emitterWith({}), THREE);
+
+      assert.lengthOf(system.emitters[0].childNodes, 0);
+    });
+  });
 });

--- a/test/emitter/Emitter.events.spec.js
+++ b/test/emitter/Emitter.events.spec.js
@@ -1,0 +1,139 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life } = Nebula;
+
+const STEP = 1 / 60;
+
+// A parent that emits one short-lived particle, carrying a `death`-trigger burst
+// child that fires once at the parent's death position.
+const build = ({
+  seed = 1,
+  parentX = 0,
+  parentLife = 0.1,
+  burstCount = 5,
+  childLife = 0.1,
+  withSmoke = false,
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(seed);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(parentLife, parentLife));
+  parent.setPosition({ x: parentX });
+
+  const burst = new Emitter();
+
+  burst
+    .setRate(new Rate(new Span(burstCount, burstCount), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife));
+  burst.trigger = 'death';
+  burst.emit(1); // one-shot burst
+
+  parent.addChild(burst);
+
+  if (withSmoke) {
+    const smoke = new Emitter();
+
+    smoke
+      .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+      .addInitializer(new Life(childLife, childLife));
+    // default trigger 'spawn' — attaches at birth
+    smoke.emit(Infinity, Infinity);
+    parent.addChild(smoke);
+  }
+
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent };
+};
+
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+const collectBurstParticleIds = system => {
+  const ids = [];
+
+  system._detached.forEach(inst => inst.particles.forEach(p => ids.push(p.id)));
+
+  return ids.sort();
+};
+
+describe('emitter -> Emitter -> events (death trigger)', () => {
+  it('does not instance a death-trigger child at parent birth', () => {
+    const { system, parent } = build();
+
+    step(system);
+
+    assert.isAbove(parent.particles.length, 0, 'parent alive');
+    assert.equal(parent.activeChildren.size, 0, 'nothing attached at birth');
+    assert.equal(system._liveEmitterInstances, 0);
+    assert.lengthOf(system._detached, 0);
+  });
+
+  it('bursts the child at the parent death position, outliving the parent', () => {
+    const { system, parent } = build({ parentX: 30, burstCount: 6 });
+
+    step(system, 10); // age the parent past its life
+
+    assert.lengthOf(parent.particles, 0, 'parent gone');
+    assert.lengthOf(system._detached, 1, 'one burst instance');
+
+    const burst = system._detached[0];
+
+    assert.equal(burst.particles.length, 6, 'burst emitted its particles');
+    assert.closeTo(burst.position.x, 30, 1e-9, 'positioned at death spot');
+    burst.particles.forEach(p =>
+      assert.closeTo(p.position.x, 30, 1e-6, 'burst particles at death spot')
+    );
+  });
+
+  it('drains and releases the burst — no leak', () => {
+    const { system } = build({ parentLife: 0.1, childLife: 0.1 });
+
+    step(system, 30);
+
+    assert.lengthOf(system._detached, 0, 'burst drained');
+    assert.equal(system._liveEmitterInstances, 0, 'instance released');
+  });
+
+  it('coexists with a spawn-trigger child: one attaches, the other bursts', () => {
+    const { system, parent } = build({ withSmoke: true });
+
+    step(system);
+    // Only the spawn child (smoke) attaches at birth.
+    assert.equal(parent.activeChildren.size, 1);
+    assert.equal(system._liveEmitterInstances, 1);
+
+    step(system, 10); // parent dies → smoke detaches, burst fires
+    // Two detached instances now: the drained-detaching smoke and the burst.
+    assert.isAtLeast(system._detached.length, 1);
+    const totalBurstParticles = system._detached.reduce(
+      (n, inst) => n + inst.particles.length,
+      0
+    );
+    assert.isAbove(totalBurstParticles, 0, 'burst produced particles');
+  });
+
+  it('is deterministic for a given seed', () => {
+    const a = build({ seed: 99 }).system;
+    const b = build({ seed: 99 }).system;
+
+    for (let i = 0; i < 12; i++) {
+      a.update(STEP);
+      b.update(STEP);
+    }
+
+    assert.deepEqual(collectBurstParticleIds(a), collectBurstParticleIds(b));
+  });
+});

--- a/test/emitter/Emitter.hierarchy.spec.js
+++ b/test/emitter/Emitter.hierarchy.spec.js
@@ -1,0 +1,197 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life } = Nebula;
+
+const STEP = 1 / 60;
+
+// Builds a two-level system: a parent that bursts N particles once, each riding
+// a child emitter that continuously emits its own particles. Lifetimes are set
+// via Life initializers so parents/children die on a known schedule.
+const build = ({
+  seed = 1234,
+  parentCount = 3,
+  parentLife = 0.2,
+  childLife = 0.1,
+  orphanPolicy = 'detach',
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(seed);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(parentCount, parentCount), new Span(0.01, 0.01)))
+    .addInitializer(new Life(parentLife, parentLife));
+
+  const child = new Emitter();
+
+  child
+    .setRate(new Rate(new Span(2, 2), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife));
+  child.orphanPolicy = orphanPolicy;
+  child.emit(Infinity, Infinity);
+
+  parent.addChild(child);
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent, child };
+};
+
+// Steps the system, ignoring the returned (already-resolved) promise.
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+// Every live particle id in the system — parents, children (recursively) and
+// detached instances — for determinism/lifecycle assertions.
+const collectParticleIds = system => {
+  const ids = [];
+  const visit = emitter => {
+    emitter.particles.forEach(p => ids.push(p.id));
+    emitter.activeChildren.forEach(instances => instances.forEach(visit));
+  };
+
+  system.emitters.forEach(visit);
+  system._detached.forEach(visit);
+
+  return ids.sort();
+};
+
+describe('emitter -> Emitter -> hierarchy', () => {
+  it('instances one child emitter per parent particle at spawn', () => {
+    const { system, parent } = build({ parentCount: 4 });
+
+    step(system);
+
+    assert.lengthOf(parent.particles, 4, 'parent burst 4 particles');
+    assert.equal(
+      parent.activeChildren.size,
+      4,
+      'one child instance per parent'
+    );
+    assert.equal(system._liveEmitterInstances, 4);
+
+    parent.activeChildren.forEach((instances, particle) => {
+      assert.lengthOf(instances, 1);
+      assert.strictEqual(instances[0]._parentParticle, particle);
+      assert.strictEqual(instances[0].parent, system, 'parented to the System');
+      assert.isTrue(instances[0].isEmitting);
+    });
+  });
+
+  it("tracks the parent particle's transform (position: always)", () => {
+    const { system, parent } = build({ parentCount: 1 });
+
+    parent.setPosition({ x: 25, y: -8 });
+    step(system);
+
+    const particle = parent.particles[0];
+    const [instance] = parent.activeChildren.get(particle);
+
+    assert.closeTo(instance.position.x, particle.position.x, 1e-9);
+    assert.closeTo(instance.position.y, particle.position.y, 1e-9);
+    assert.isAbove(instance.particles.length, 0, 'child emitted particles');
+  });
+
+  it('stamps each particle with the id of the emitter that spawned it', () => {
+    const { system, parent } = build({ parentCount: 1 });
+
+    step(system);
+
+    const particle = parent.particles[0];
+    const [instance] = parent.activeChildren.get(particle);
+
+    assert.equal(particle.emitterId, '0', 'top-level node id');
+    assert.equal(instance.particles[0].emitterId, '0/children/0');
+  });
+
+  it('detaches child instances when their parent dies, draining then releasing', () => {
+    const { system, parent } = build({
+      parentCount: 2,
+      parentLife: 0.1,
+      childLife: 0.1,
+      orphanPolicy: 'detach',
+    });
+
+    step(system); // parents + children spawn
+    assert.equal(system._liveEmitterInstances, 2);
+
+    // Age past the parents' life so they die and their children detach.
+    step(system, 8);
+    assert.lengthOf(parent.particles, 0, 'parents gone');
+    assert.isAbove(system._detached.length, 0, 'children detached, not killed');
+    system._detached.forEach(inst => assert.isFalse(inst.isEmitting));
+
+    // Age past the detached children's particle life; they drain and release.
+    step(system, 12);
+    assert.lengthOf(system._detached, 0, 'detached instances drained');
+    assert.equal(system._liveEmitterInstances, 0);
+  });
+
+  it('kills child instances (and their particles) with the parent under orphanPolicy: kill', () => {
+    const { system, parent } = build({
+      parentCount: 2,
+      parentLife: 0.1,
+      childLife: 10, // long — proves kill is immediate, not lifetime-driven
+      orphanPolicy: 'kill',
+    });
+
+    step(system);
+    assert.equal(system._liveEmitterInstances, 2);
+
+    step(system, 8); // parents die
+    assert.lengthOf(parent.particles, 0);
+    assert.lengthOf(system._detached, 0, 'kill does not detach');
+    assert.equal(system._liveEmitterInstances, 0, 'instances released at once');
+  });
+
+  it('recycles child instances across parent lifecycles', () => {
+    const { system } = build({
+      parentCount: 2,
+      parentLife: 0.1,
+      childLife: 0.05,
+    });
+
+    // Run long enough for a full spawn→detach→drain→release cycle.
+    step(system, 25);
+
+    assert.isAbove(system._emitterPoolHits + system._emitterPoolMisses, 0);
+    assert.equal(system._liveEmitterInstances, 0, 'nothing leaked');
+  });
+
+  it('produces identical output for the same seed (determinism)', () => {
+    const a = build({ seed: 777 }).system;
+    const b = build({ seed: 777 }).system;
+
+    for (let i = 0; i < 10; i++) {
+      a.update(STEP);
+      b.update(STEP);
+
+      assert.deepEqual(collectParticleIds(a), collectParticleIds(b));
+    }
+  });
+
+  it('rejects a hierarchy deeper than maxEmitterDepth', () => {
+    const system = new System(); // default maxEmitterDepth = 4
+    const root = new Emitter();
+
+    let node = root;
+
+    // root (0) + 5 nested children => deepest node at depth 5 > 4.
+    for (let i = 0; i < 5; i++) {
+      const next = new Emitter();
+
+      node.addChild(next);
+      node = next;
+    }
+
+    assert.throws(() => system.addEmitter(root), /maxDepth/);
+  });
+});

--- a/test/emitter/Emitter.inheritance.spec.js
+++ b/test/emitter/Emitter.inheritance.spec.js
@@ -1,0 +1,217 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life, Radius } = Nebula;
+
+const STEP = 1 / 60;
+
+// A parent that emits one long-lived, stationary particle, carrying a child whose
+// inherit modes are set per-test. The parent particle stays put (no velocity), so
+// tests can move/scale it by hand and observe how the child responds.
+const build = ({
+  inherit = {},
+  childRadius = 10,
+  childLife = 100,
+  parentX = 0,
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(4242);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(100, 100));
+  parent.setPosition({ x: parentX });
+
+  const child = new Emitter();
+
+  child
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife))
+    .addInitializer(new Radius(childRadius, childRadius));
+  // Start from all-none and override per test, for isolation.
+  child.inherit = {
+    position: 'none',
+    rotation: 'none',
+    scale: 'none',
+    ...inherit,
+  };
+  child.emit(Infinity, Infinity);
+
+  parent.addChild(child);
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent };
+};
+
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+// The single child instance riding the single parent particle.
+const soleInstance = parent => {
+  const particle = parent.particles[0];
+
+  return { particle, instance: parent.activeChildren.get(particle)[0] };
+};
+
+describe('emitter -> Emitter -> inheritance modes', () => {
+  describe('position', () => {
+    it('always: the child tracks the parent every frame', () => {
+      const { system, parent } = build({
+        inherit: { position: 'always' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'snapshots at spawn');
+
+      particle.position.set(50, 60, 0);
+      step(system);
+
+      assert.closeTo(instance.position.x, 50, 1e-9, 'follows the parent');
+      assert.closeTo(instance.position.y, 60, 1e-9);
+    });
+
+    it('onCreate: the child snapshots at spawn then stays put', () => {
+      const { system, parent } = build({
+        inherit: { position: 'onCreate' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'snapshot taken');
+
+      particle.position.set(50, 0, 0);
+      step(system);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'does not follow');
+    });
+
+    it('none: the child ignores the parent (system space)', () => {
+      const { system, parent } = build({
+        inherit: { position: 'none' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.equal(instance.position.x, 0, 'stays in system space');
+
+      particle.position.set(50, 0, 0);
+      step(system);
+
+      assert.equal(instance.position.x, 0);
+    });
+  });
+
+  describe('rotation', () => {
+    it('always tracks, onCreate snapshots, none ignores', () => {
+      const always = build({ inherit: { rotation: 'always' } });
+      const onCreate = build({ inherit: { rotation: 'onCreate' } });
+      const none = build({ inherit: { rotation: 'none' } });
+
+      [always, onCreate, none].forEach(({ system }) => step(system));
+
+      const a = soleInstance(always.parent);
+      const o = soleInstance(onCreate.parent);
+      const n = soleInstance(none.parent);
+
+      // Spin every parent particle after spawn.
+      [a, o, n].forEach(({ particle }) => particle.rotation.set(1, 2, 3));
+      [always, onCreate, none].forEach(({ system }) => step(system));
+
+      assert.closeTo(a.instance.rotation.z, 3, 1e-9, 'always follows');
+      assert.equal(o.instance.rotation.z, 0, 'onCreate kept its 0 snapshot');
+      assert.equal(n.instance.rotation.z, 0, 'none ignores');
+    });
+  });
+
+  describe('scale', () => {
+    it('always: bakes the current parent scale into new child radii', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'always' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      instance.particles.forEach(p =>
+        assert.closeTo(p.radius, 10, 1e-6, 'parent scale 1 → radius unchanged')
+      );
+
+      particle.scale = 4;
+      step(system, 3);
+
+      const scaled = instance.particles.filter(p => p.radius > 30);
+
+      assert.isAbove(scaled.length, 0, 'new child particles grew with parent');
+    });
+
+    it('onCreate: snapshots the parent scale, ignoring later changes', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'onCreate' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      particle.scale = 4;
+      step(system, 3);
+
+      instance.particles.forEach(p =>
+        assert.closeTo(p.radius, 10, 1e-6, 'radius fixed at the spawn snapshot')
+      );
+    });
+
+    it('none: parent scale never touches child radius', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'none' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      particle.scale = 9;
+      step(system, 3);
+
+      instance.particles.forEach(p => assert.closeTo(p.radius, 10, 1e-6));
+    });
+  });
+
+  it('acceptance: flipping position always→onCreate turns an attached trail into a left-behind band', () => {
+    // Same system, one knob. `always` keeps the child pinned to the moving
+    // parent; `onCreate` leaves it where the parent was at spawn.
+    const attached = build({ inherit: { position: 'always' }, parentX: 5 });
+    const band = build({ inherit: { position: 'onCreate' }, parentX: 5 });
+
+    step(attached.system);
+    step(band.system);
+
+    const a = soleInstance(attached.parent);
+    const b = soleInstance(band.parent);
+
+    a.particle.position.set(200, 0, 0);
+    b.particle.position.set(200, 0, 0);
+    step(attached.system);
+    step(band.system);
+
+    assert.closeTo(a.instance.position.x, 200, 1e-9, 'attached: rides along');
+    assert.closeTo(b.instance.position.x, 5, 1e-9, 'band: stays behind');
+  });
+});

--- a/test/emitter/Emitter.instancePool.spec.js
+++ b/test/emitter/Emitter.instancePool.spec.js
@@ -1,0 +1,156 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { Emitter, System, Rate, Span } = Nebula;
+
+// A minimal stand-in for a parent particle — acquireInstance only reads `.id`.
+const parent = id => ({ id });
+
+// Builds a child-emitter *template*: a normal emitter with a tree-path nodeId,
+// exactly as the hierarchy loader (Stage 2) will produce.
+const makeNode = (nodeId = '0/children/0') => {
+  const node = new Emitter();
+
+  node.nodeId = nodeId;
+  node.setRate(new Rate(new Span(1, 1), new Span(0.1, 0.1)));
+
+  return node;
+};
+
+describe('emitter -> Emitter -> instance pool', () => {
+  it('acquires a cold instance that shares config but owns its runtime state', () => {
+    const node = makeNode();
+    const inst = node.acquireInstance(parent('particle-1-0'));
+
+    // Shared-by-reference config (read-only during simulation).
+    assert.strictEqual(inst.initializers, node.initializers);
+    assert.strictEqual(inst.behaviours, node.behaviours);
+    assert.strictEqual(inst.emitterBehaviours, node.emitterBehaviours);
+    assert.strictEqual(inst.childNodes, node.childNodes);
+
+    // Per-instance mutable state.
+    assert.notStrictEqual(inst.rate, node.rate, 'instance gets its own Rate');
+    assert.strictEqual(inst.rate.numPan, node.rate.numPan, 'sharing the Spans');
+    assert.notStrictEqual(inst.particles, node.particles);
+    assert.strictEqual(inst._template, node);
+    assert.strictEqual(inst.nodeId, node.nodeId);
+    assert.isTrue(inst.isEmitting);
+  });
+
+  it('recycles a released instance on the next acquire (no new allocation)', () => {
+    const node = makeNode();
+    const a = node.acquireInstance(parent('particle-1-0'));
+
+    node.releaseInstance(a);
+    assert.isFalse(a.isEmitting);
+    assert.lengthOf(node._freeInstances, 1);
+
+    const b = node.acquireInstance(parent('particle-1-1'));
+
+    assert.strictEqual(b, a, 'the freed instance is reused');
+    assert.lengthOf(node._freeInstances, 0);
+  });
+
+  it('keeps the instance pool bounded by live instances under heavy churn', () => {
+    // Mirror the renderer lifecycle: every parent particle spawns a fresh child
+    // instance, but at most `live` are alive at once. The free-list must bound
+    // the total object count to the live high-water mark, not cumulative spawns.
+    const node = makeNode();
+    const live = 8;
+    const totalSpawns = 5000;
+    const alive = [];
+
+    for (let i = 0; i < totalSpawns; i++) {
+      alive.push(node.acquireInstance(parent(`particle-1-${i}`)));
+
+      if (alive.length > live) {
+        node.releaseInstance(alive.shift());
+      }
+    }
+
+    // Objects ever created = the live high-water mark, everything else recycled.
+    const created = node._freeInstances.length + alive.length;
+
+    assert.isAtMost(created, live + 1, 'no growth with cumulative spawns');
+  });
+
+  it('resets runtime state so a recycled instance is indistinguishable from cold', () => {
+    const node = makeNode();
+    const a = node.acquireInstance(parent('particle-1-0'));
+
+    a.age = 5;
+    a.dead = true;
+    a.particles.push({});
+    a.position.set(3, 4, 5);
+    node.releaseInstance(a);
+
+    const b = node.acquireInstance(parent('particle-1-1'));
+
+    assert.strictEqual(b, a);
+    assert.equal(b.age, 0);
+    assert.isFalse(b.dead);
+    assert.lengthOf(b.particles, 0);
+    assert.equal(b.position.x, 0);
+    assert.equal(b._parentParticle.id, 'particle-1-1');
+  });
+
+  it('derives a deterministic seed from node id + parent particle id', () => {
+    const node = makeNode();
+    const a = node.acquireInstance(parent('particle-1-42'));
+    const seedA = a.seed;
+
+    node.releaseInstance(a);
+
+    // Same node + same parent id → identical seed, regardless of pooling.
+    const b = node.acquireInstance(parent('particle-1-42'));
+    assert.equal(b.seed, seedA);
+
+    // Different parent id → different stream.
+    node.releaseInstance(b);
+    const c = node.acquireInstance(parent('particle-1-43'));
+    assert.notEqual(c.seed, seedA);
+  });
+});
+
+describe('core -> System -> emitter instance cap', () => {
+  it('spawns instances, tracking pool hits/misses and the live count', () => {
+    const system = new System();
+    const node = makeNode();
+
+    const a = system.spawnEmitterInstance(node, parent('particle-1-0'));
+
+    assert.instanceOf(a, Emitter);
+    assert.equal(system._liveEmitterInstances, 1);
+    assert.equal(system._emitterPoolMisses, 1, 'cold acquire is a miss');
+    assert.equal(system._emitterPoolHits, 0);
+
+    system.releaseEmitterInstance(a);
+    assert.equal(system._liveEmitterInstances, 0);
+
+    system.spawnEmitterInstance(node, parent('particle-1-1'));
+    assert.equal(system._emitterPoolHits, 1, 'recycled acquire is a hit');
+  });
+
+  it('drops the newest instance and warns once past maxEmitterInstances', () => {
+    const system = new System();
+    const node = makeNode();
+
+    system.maxEmitterInstances = 2;
+
+    assert.instanceOf(
+      system.spawnEmitterInstance(node, parent('p-0')),
+      Emitter
+    );
+    assert.instanceOf(
+      system.spawnEmitterInstance(node, parent('p-1')),
+      Emitter
+    );
+
+    // Third exceeds the cap → dropped.
+    assert.isNull(system.spawnEmitterInstance(node, parent('p-2')));
+    assert.equal(system._liveEmitterInstances, 2);
+    assert.isTrue(system._warnedInstanceOverflow);
+  });
+});

--- a/test/renderer/RibbonRenderer.spec.js
+++ b/test/renderer/RibbonRenderer.spec.js
@@ -1,0 +1,158 @@
+import * as THREE from 'three';
+
+import RibbonRenderer, {
+  bySpawnIndex,
+  ribbonIndices,
+} from '../../src/renderer/RibbonRenderer';
+import chai from 'chai';
+
+const { assert } = chai;
+
+// A minimal stand-in for a particle — the renderer only reads these fields.
+const particle = ({
+  instance = 'i0',
+  spawnIndex = 0,
+  x = 0,
+  y = 0,
+  z = 0,
+  scale = 1,
+} = {}) => ({
+  emitterInstanceId: instance,
+  emitterId: null,
+  spawnIndex,
+  position: new THREE.Vector3(x, y, z),
+  color: { r: 1, g: 1, b: 1 },
+  alpha: 1,
+  scale,
+});
+
+describe('renderer -> RibbonRenderer -> helpers', () => {
+  it('orders a spine by spawn index', () => {
+    const spine = [
+      particle({ spawnIndex: 2 }),
+      particle({ spawnIndex: 0 }),
+      particle({ spawnIndex: 1 }),
+    ].sort(bySpawnIndex);
+
+    assert.deepEqual(
+      spine.map(p => p.spawnIndex),
+      [0, 1, 2]
+    );
+  });
+
+  it('builds two triangles (6 indices) per segment', () => {
+    assert.deepEqual(ribbonIndices(1), [], 'no segments for a single point');
+    assert.lengthOf(ribbonIndices(2), 6, 'one segment');
+    assert.lengthOf(ribbonIndices(4), 18, 'three segments');
+    // First segment references points 0 and 1 (vertices 0..3).
+    assert.deepEqual(ribbonIndices(2), [0, 2, 1, 1, 2, 3]);
+  });
+});
+
+describe('renderer -> RibbonRenderer -> grouping', () => {
+  const makeRenderer = () =>
+    new RibbonRenderer(new THREE.Object3D(), THREE, { camera: undefined });
+
+  it('groups live particles by emitter instance', () => {
+    const r = makeRenderer();
+
+    r.onParticleCreated(particle({ instance: 'a', spawnIndex: 0 }));
+    r.onParticleCreated(particle({ instance: 'b', spawnIndex: 0 }));
+    r.onParticleCreated(particle({ instance: 'a', spawnIndex: 1 }));
+
+    assert.equal(r._groups.size, 2);
+    assert.lengthOf(r._groups.get('a'), 2);
+    assert.lengthOf(r._groups.get('b'), 1);
+  });
+
+  it('removes a dead particle and disposes an emptied ribbon', () => {
+    const r = makeRenderer();
+    const p0 = particle({ instance: 'a', spawnIndex: 0 });
+    const p1 = particle({ instance: 'a', spawnIndex: 1 });
+
+    r.onParticleCreated(p0);
+    r.onParticleCreated(p1);
+    r.onSystemUpdate(); // builds the ribbon mesh
+
+    assert.isTrue(r._ribbons.has('a'));
+
+    r.onParticleDead(p0);
+    assert.lengthOf(r._groups.get('a'), 1);
+
+    r.onParticleDead(p1);
+    assert.isFalse(r._groups.has('a'), 'group gone');
+    assert.isFalse(r._ribbons.has('a'), 'ribbon disposed');
+  });
+
+  it('falls back to emitterId, then a shared bucket, for the group key', () => {
+    const r = makeRenderer();
+
+    r.onParticleCreated({
+      ...particle(),
+      emitterInstanceId: null,
+      emitterId: 'node0',
+    });
+    r.onParticleCreated({
+      ...particle(),
+      emitterInstanceId: null,
+      emitterId: null,
+    });
+
+    assert.isTrue(r._groups.has('node0'));
+    assert.isTrue(r._groups.has('ribbon'));
+  });
+});
+
+describe('renderer -> RibbonRenderer -> rebuild', () => {
+  const makeRenderer = () => new RibbonRenderer(new THREE.Object3D(), THREE);
+
+  it('hides a strip with fewer than two live points', () => {
+    const r = makeRenderer();
+
+    r.onParticleCreated(particle({ instance: 'a' }));
+    r.onSystemUpdate();
+
+    assert.isFalse(r._ribbons.get('a').mesh.visible);
+  });
+
+  it('builds a visible, NaN-free strip and sets the draw range', () => {
+    const r = makeRenderer();
+
+    for (let i = 0; i < 4; i++) {
+      r.onParticleCreated(
+        particle({ instance: 'a', spawnIndex: i, x: i * 10 })
+      );
+    }
+
+    r.onSystemUpdate();
+
+    const ribbon = r._ribbons.get('a');
+
+    assert.isTrue(ribbon.mesh.visible);
+    // 4 points → 3 segments → 18 indices.
+    assert.equal(ribbon.geometry.drawRange.count, 18);
+    assert.isAtLeast(ribbon.capacity, 4);
+
+    const pos = ribbon.geometry.attributes.position.array;
+    for (let i = 0; i < 4 * 6; i++) {
+      assert.isFalse(Number.isNaN(pos[i]), `position[${i}] is finite`);
+    }
+  });
+
+  it('grows buffers as the spine lengthens, keeping the high-water capacity', () => {
+    const r = makeRenderer();
+
+    for (let i = 0; i < 3; i++) {
+      r.onParticleCreated(particle({ instance: 'a', spawnIndex: i, x: i }));
+    }
+    r.onSystemUpdate();
+    assert.isAtLeast(r._ribbons.get('a').capacity, 3);
+
+    for (let i = 3; i < 12; i++) {
+      r.onParticleCreated(particle({ instance: 'a', spawnIndex: i, x: i }));
+    }
+    r.onSystemUpdate();
+    assert.isAtLeast(r._ribbons.get('a').capacity, 12);
+    assert.equal(r._ribbons.get('a').geometry.drawRange.count, 11 * 6);
+  });
+});


### PR DESCRIPTION
Umbrella / integration PR for **spec 01 — Emitter Hierarchy**. This is the branch the five-stage stack collapses into, and the one that lands the whole feature on `develop`.

## ⚠️ Merge order

**This PR merges _last_.** Right now its diff is only **Stage 0 (audit) + Stage 1 (pooling)** — the rest lives on the stacked PRs below and flows onto this branch as they merge bottom-up:

| PR | Stage | Into |
|----|-------|------|
| #321 | Stage 2 — nesting, instancing, orphan lifecycle | `feat/emitter-hierarchy` |
| #322 | Stage 3 — per-channel inheritance modes | (Stage 2) |
| #323 | Stage 4 — RibbonRenderer | (Stage 3) |
| #324 | Stage 5 — event bursts (onDeath) | (Stage 4) |

Merge #321 → this branch, then #322…#324 in order (GitHub retargets each base as the one below merges). Once the stack has collapsed onto `feat/emitter-hierarchy`, this PR contains the complete feature and merges to `develop`.

## What the feature delivers

A child emitter can be nested under a parent and instanced **once per parent particle**, riding it — turning "every spark leaves its own smoke trail" from unrepresentable into a `children[]` entry. All additive: a childless emitter is byte-for-byte today's flat emitter.

- **Stage 1 — Pooling.** Per-node emitter-instance free-list, global cap (drop-newest + warn-once), pool/live instrumentation. Bounds instance count by *live* particles, not cumulative spawns.
- **Stage 2 — The tree.** `children[]` in both `fromJSON` paths; tree-path node ids + `maxDepth` guard; per-parent instancing; depth-first (topological) update; `detach`/`kill` orphan lifecycle for a dead parent's children.
- **Stage 3 — Inheritance.** `position`/`rotation`/`scale` × `always`/`onCreate`/`none`. (`scale` bakes into `radius` at birth, since Scale behaviours overwrite `scale`.)
- **Stage 4 — RibbonRenderer.** Connects an emitter instance's particles into one camera-facing strip (one per `emitterInstanceId`) — the `onCreate` payoff.
- **Stage 5 — Events.** Child `trigger: 'death'` bursts at the parent's death position and outlives it (fireworks).

Determinism carried throughout: a child instance's seed is `hash(nodeId, parentParticleId)` — which is why spec 02 (determinism) shipped first.

## Verification (at Stage 5 tip)

317 tests pass (pooling, hierarchy lifecycle, inheritance modes, ribbon geometry, event bursts, determinism); `tsc`/lint/format/madge clean. Sandbox demos: `emitter-hierarchy` (healing aura), `ribbon-trails`, `fireworks`.

## Deferred / filed separately

- `trigger: 'collision'` — feasible via the existing `Collision` behaviour's `onCollide` hook (contact-point burst), deferred for O(n²) cost, per-pair debouncing, and its non-JSON-serializable `fromJSON` stub.
- SphereZone centre-Y/Z bug (`fix/sphere-zone-center`) and per-emitter renderer routing (spec 10) filed on their own branches.