### PR TITLE
Stage 3 — complete per-channel inheritance (replaces #322)

### DIFF
--- a/sandbox/experiments/emitter-hierarchy/index.html
+++ b/sandbox/experiments/emitter-hierarchy/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Emitter Hierarchy — sparks leaving smoke trails</title>
+    <title>Emitter Hierarchy — healing aura</title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="/style/reset.css" />

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -18,10 +18,18 @@ import System, {
 import { run } from '/common/run.js';
 
 // Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
-// outward; each spark rides a child "smoke" emitter (inherit.position: 'always',
-// orphanPolicy: 'detach') so the smoke follows its spark and lives on after the
-// spark dies. One child node → one live instance per spark, all recycled through
-// the Stage 1 pool.
+// outward; each spark rides a child "smoke" emitter (orphanPolicy: 'detach') so
+// the smoke follows its spark and lives on after the spark dies. One child node →
+// one live instance per spark, all recycled through the Stage 1 pool.
+//
+// Stage 3 inheritance modes are on show:
+//   - scale: 'always'    smoke puffs shrink as the spark shrinks
+//   - position: 'always' (default) smoke rides the spark; append
+//     ?position=onCreate to leave a stationary band where each spark was born.
+const positionMode =
+  new URLSearchParams(window.location.search).get('position') === 'onCreate'
+    ? 'onCreate'
+    : 'always';
 
 const createSprite = color => {
   const map = new THREE.TextureLoader().load('/assets/dot.png');
@@ -55,8 +63,9 @@ const createSmokeTrail = () => {
       new Color('#aaaaaa', '#222222'),
     ]);
 
-  // Follow the parent spark every frame; let emitted smoke outlive the spark.
-  smoke.inherit = { position: 'always', rotation: 'none', scale: 'none' };
+  // Track the spark's position (see positionMode) and shrink with it (scale);
+  // let emitted smoke outlive the spark.
+  smoke.inherit = { position: positionMode, rotation: 'none', scale: 'always' };
   smoke.orphanPolicy = 'detach';
   smoke.emit(Infinity, Infinity);
 

--- a/sandbox/experiments/emitter-hierarchy/index.js
+++ b/sandbox/experiments/emitter-hierarchy/index.js
@@ -7,29 +7,38 @@ import System, {
   Force,
   Life,
   Mass,
+  Position,
   RadialVelocity,
   Radius,
+  RandomDrift,
   Rate,
   Scale,
+  SphereZone,
   Span,
+  VectorVelocity,
   GPURenderer,
   Vector3D,
 } from 'three-nebula';
 import { run } from '/common/run.js';
 
-// Emitter hierarchy (spec 01): the parent "sparks" emitter throws sprites
-// outward; each spark rides a child "smoke" emitter (orphanPolicy: 'detach') so
-// the smoke follows its spark and lives on after the spark dies. One child node →
-// one live instance per spark, all recycled through the Stage 1 pool.
+// Healing aura — a designed showcase of the emitter hierarchy (spec 01).
 //
-// Stage 3 inheritance modes are on show:
-//   - scale: 'always'    smoke puffs shrink as the spark shrinks
-//   - position: 'always' (default) smoke rides the spark; append
-//     ?position=onCreate to leave a stationary band where each spark was born.
+// A ground cluster lifts soft green→gold "motes" (parent). Each mote rides a
+// child "sparkle" emitter that inherits its transform, so the sparkles ride the
+// mote up the column and — because scale is inherited — shrink as the mote fades.
+// orphanPolicy 'detach' lets a mote's sparkles twinkle out on their own after the
+// mote dies. One child node → one live sparkle emitter per mote, all recycled
+// through the pool.
+//
+// Append ?position=onCreate to switch the sparkles from riding the mote (a
+// trailing shimmer) to snapping to where the mote was born (a standing pillar of
+// light) — the Stage 3 always↔onCreate contrast.
 const positionMode =
   new URLSearchParams(window.location.search).get('position') === 'onCreate'
     ? 'onCreate'
     : 'always';
+
+const BASE_Y = -120;
 
 const createSprite = color => {
   const map = new THREE.TextureLoader().load('/assets/dot.png');
@@ -44,64 +53,70 @@ const createSprite = color => {
   );
 };
 
-// The child: a slow, greying puff that trails whichever spark spawned it.
-const createSmokeTrail = () => {
-  const smoke = new Emitter();
+// The child: a small, bright twinkle that rides (or is left behind by) its mote.
+const createSparkles = () => {
+  const sparkles = new Emitter();
 
-  smoke
-    .setRate(new Rate(new Span(1, 2), new Span(0.02, 0.04)))
+  sparkles
+    .setRate(new Rate(new Span(1, 2), new Span(0.03, 0.06)))
     .setInitializers([
       new Mass(1),
-      new Life(0.6, 1.1),
-      new Body(createSprite(0x888888)),
-      new Radius(16, 32),
-      new RadialVelocity(15, new Vector3D(0, 1, 0), 30),
-    ])
-    .setBehaviours([
-      new Alpha(0.35, 0),
-      new Scale(0.5, 1.6),
-      new Color('#aaaaaa', '#222222'),
-    ]);
-
-  // Track the spark's position (see positionMode) and shrink with it (scale);
-  // let emitted smoke outlive the spark.
-  smoke.inherit = { position: positionMode, rotation: 'none', scale: 'always' };
-  smoke.orphanPolicy = 'detach';
-  smoke.emit(Infinity, Infinity);
-
-  return smoke;
-};
-
-// The parent: bright, fast sparks under gravity, each carrying a smoke child.
-const createSparks = () => {
-  const sparks = new Emitter();
-
-  sparks
-    .setRate(new Rate(new Span(2, 4), new Span(0.06, 0.1)))
-    .setInitializers([
-      new Mass(1),
-      new Life(1.1, 1.7),
-      new Body(createSprite(0xffcc33)),
-      new Radius(26, 46),
-      new RadialVelocity(220, new Vector3D(0, 1, 0), 55),
+      new Life(0.35, 0.7),
+      new Body(createSprite(0xffffff)),
+      new Radius(3, 6),
+      new RadialVelocity(16, new Vector3D(0, 1, 0), 70),
     ])
     .setBehaviours([
       new Alpha(1, 0),
-      new Scale(1, 0.25),
-      new Color('#fffb00', '#ff3c00'),
-      new Force(0, -140, 0),
+      new Color('#ffffff', '#ffd86b'),
+      new Scale(1, 0.1),
     ]);
 
-  sparks.addChild(createSmokeTrail());
+  // Ride the mote (position) and shrink with it (scale); linger after it dies.
+  sparkles.inherit = {
+    position: positionMode,
+    rotation: 'none',
+    scale: 'always',
+  };
+  sparkles.orphanPolicy = 'detach';
+  sparkles.emit(Infinity, Infinity);
 
-  return sparks.emit();
+  return sparkles;
+};
+
+// The parent: soft motes rising from a base cluster, greening into gold.
+const createMotes = () => {
+  const motes = new Emitter();
+
+  motes
+    .setRate(new Rate(new Span(3, 5), new Span(0.02, 0.04)))
+    .setInitializers([
+      new Mass(1),
+      new Life(1.6, 2.6),
+      new Body(createSprite(0xffffff)),
+      new Radius(8, 16),
+      new Position(new SphereZone(45)),
+      new VectorVelocity(new Vector3D(0, 90, 0), 25),
+    ])
+    .setBehaviours([
+      new Alpha(1, 0),
+      new Color('#7cffb0', '#ffe68a'),
+      new Scale(0.7, 1.5),
+      new RandomDrift(18, 8, 18, 0.1),
+      new Force(0, 30, 0),
+    ]);
+
+  motes.setPosition({ x: 0, y: BASE_Y, z: 0 });
+  motes.addChild(createSparkles());
+
+  return motes.emit();
 };
 
 const init = async ({ scene }) => {
   const system = new System();
 
   return system
-    .addEmitter(createSparks())
+    .addEmitter(createMotes())
     .addRenderer(new GPURenderer(scene, THREE));
 };
 

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,8 +12,8 @@
       <ul>
         <li>
           <a href="experiments/emitter-hierarchy/index.html">
-            Emitter Hierarchy — sparks leaving smoke trails (child emitters) —
-            add ?position=onCreate for left-behind bands
+            Emitter Hierarchy — healing aura (motes each trailing a sparkle
+            child) — add ?position=onCreate for a standing pillar
           </a>
         </li>
         <li>

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -12,7 +12,8 @@
       <ul>
         <li>
           <a href="experiments/emitter-hierarchy/index.html">
-            Emitter Hierarchy — sparks leaving smoke trails (child emitters)
+            Emitter Hierarchy — sparks leaving smoke trails (child emitters) —
+            add ?position=onCreate for left-behind bands
           </a>
         </li>
         <li>

--- a/src/emitter/Emitter.ts
+++ b/src/emitter/Emitter.ts
@@ -52,11 +52,20 @@ export interface InheritConfig {
 /** What becomes of a dead parent's already-emitted child particles. */
 export type OrphanPolicy = 'kill' | 'detach';
 
+/** True when a channel should be applied on this call (Stage 3). */
+const shouldInherit = (mode: InheritMode, atSpawn: boolean): boolean =>
+  mode === 'always' || (atSpawn && mode === 'onCreate');
+
 /**
- * Copies the parent particle's transform onto a child instance according to its
- * `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
- * per-frame call (atSpawn=false) only re-applies the continuous `always` mode.
- * Scale inheritance is deferred to Stage 3 (it needs a per-emitter scale offset).
+ * Reflects the parent particle's transform onto a child instance according to
+ * its `inherit` config. `atSpawn` runs the one-shot `onCreate` snapshot; the
+ * per-frame call (atSpawn=false) only re-applies continuous `always` channels.
+ *
+ * Position and rotation copy directly onto the instance (which bindEmitter then
+ * adds to each emitted particle). Scale can't do the same — a Scale behaviour
+ * overwrites `particle.scale` every frame — so the parent's scale is captured
+ * here and baked into each child particle's `radius` at birth (see setupParticle),
+ * which behaviours leave alone.
  */
 const applyInheritance = (
   inst: Emitter,
@@ -65,18 +74,16 @@ const applyInheritance = (
 ): void => {
   const { inherit } = inst;
 
-  if (
-    inherit.position === 'always' ||
-    (atSpawn && inherit.position === 'onCreate')
-  ) {
+  if (shouldInherit(inherit.position, atSpawn)) {
     inst.position.copy(particle.position);
   }
 
-  if (
-    inherit.rotation === 'always' ||
-    (atSpawn && inherit.rotation === 'onCreate')
-  ) {
+  if (shouldInherit(inherit.rotation, atSpawn)) {
     inst.rotation.copy(particle.rotation);
+  }
+
+  if (shouldInherit(inherit.scale, atSpawn)) {
+    inst._inheritedScale = particle.scale;
   }
 };
 
@@ -120,6 +127,9 @@ export default class Emitter extends Particle {
   orphanPolicy: OrphanPolicy;
   _template: Emitter | null;
   _parentParticle: Particle | null;
+  // The parent particle's scale captured for `inherit.scale`, baked into each
+  // child particle's radius at birth. 1 when scale is not inherited.
+  _inheritedScale: number;
   _freeInstances: Emitter[];
   // Live child instances riding each of this emitter's still-alive particles,
   // keyed by the parent particle so they can be orphaned when it dies. On a live
@@ -143,6 +153,7 @@ export default class Emitter extends Particle {
     this.orphanPolicy = DEFAULT_ORPHAN_POLICY;
     this._template = null;
     this._parentParticle = null;
+    this._inheritedScale = 1;
     this._freeInstances = [];
     this.activeChildren = new Map();
     this.particles = [];
@@ -245,6 +256,7 @@ export default class Emitter extends Particle {
     this.particles.length = 0;
     this.activeChildren.clear();
     this._parentParticle = null;
+    this._inheritedScale = 1;
     this.position.set(0, 0, 0);
     this.rotation.clear();
   }
@@ -742,6 +754,12 @@ export default class Emitter extends Particle {
     particle.emitterId = this.nodeId || null;
 
     InitializerUtil.initialize(this, particle, initializers);
+
+    // Bake inherited parent scale into radius (Scale behaviours overwrite
+    // `scale` each frame; radius they leave alone). 1 for non-inheriting emitters.
+    if (this._inheritedScale !== 1) {
+      particle.radius *= this._inheritedScale;
+    }
 
     particle.addBehaviours(behaviours);
     particle.parent = this;

--- a/test/emitter/Emitter.inheritance.spec.js
+++ b/test/emitter/Emitter.inheritance.spec.js
@@ -1,0 +1,217 @@
+import * as Nebula from '../../src';
+
+import chai from 'chai';
+
+const { assert } = chai;
+const { System, Emitter, Rate, Span, Life, Radius } = Nebula;
+
+const STEP = 1 / 60;
+
+// A parent that emits one long-lived, stationary particle, carrying a child whose
+// inherit modes are set per-test. The parent particle stays put (no velocity), so
+// tests can move/scale it by hand and observe how the child responds.
+const build = ({
+  inherit = {},
+  childRadius = 10,
+  childLife = 100,
+  parentX = 0,
+} = {}) => {
+  const system = new System();
+
+  system.setSeed(4242);
+
+  const parent = new Emitter();
+
+  parent
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(100, 100));
+  parent.setPosition({ x: parentX });
+
+  const child = new Emitter();
+
+  child
+    .setRate(new Rate(new Span(1, 1), new Span(0.01, 0.01)))
+    .addInitializer(new Life(childLife, childLife))
+    .addInitializer(new Radius(childRadius, childRadius));
+  // Start from all-none and override per test, for isolation.
+  child.inherit = {
+    position: 'none',
+    rotation: 'none',
+    scale: 'none',
+    ...inherit,
+  };
+  child.emit(Infinity, Infinity);
+
+  parent.addChild(child);
+  system.addEmitter(parent);
+  parent.emit(1);
+
+  return { system, parent };
+};
+
+const step = (system, n = 1) => {
+  for (let i = 0; i < n; i++) {
+    system.update(STEP);
+  }
+};
+
+// The single child instance riding the single parent particle.
+const soleInstance = parent => {
+  const particle = parent.particles[0];
+
+  return { particle, instance: parent.activeChildren.get(particle)[0] };
+};
+
+describe('emitter -> Emitter -> inheritance modes', () => {
+  describe('position', () => {
+    it('always: the child tracks the parent every frame', () => {
+      const { system, parent } = build({
+        inherit: { position: 'always' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'snapshots at spawn');
+
+      particle.position.set(50, 60, 0);
+      step(system);
+
+      assert.closeTo(instance.position.x, 50, 1e-9, 'follows the parent');
+      assert.closeTo(instance.position.y, 60, 1e-9);
+    });
+
+    it('onCreate: the child snapshots at spawn then stays put', () => {
+      const { system, parent } = build({
+        inherit: { position: 'onCreate' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'snapshot taken');
+
+      particle.position.set(50, 0, 0);
+      step(system);
+
+      assert.closeTo(instance.position.x, 10, 1e-9, 'does not follow');
+    });
+
+    it('none: the child ignores the parent (system space)', () => {
+      const { system, parent } = build({
+        inherit: { position: 'none' },
+        parentX: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      assert.equal(instance.position.x, 0, 'stays in system space');
+
+      particle.position.set(50, 0, 0);
+      step(system);
+
+      assert.equal(instance.position.x, 0);
+    });
+  });
+
+  describe('rotation', () => {
+    it('always tracks, onCreate snapshots, none ignores', () => {
+      const always = build({ inherit: { rotation: 'always' } });
+      const onCreate = build({ inherit: { rotation: 'onCreate' } });
+      const none = build({ inherit: { rotation: 'none' } });
+
+      [always, onCreate, none].forEach(({ system }) => step(system));
+
+      const a = soleInstance(always.parent);
+      const o = soleInstance(onCreate.parent);
+      const n = soleInstance(none.parent);
+
+      // Spin every parent particle after spawn.
+      [a, o, n].forEach(({ particle }) => particle.rotation.set(1, 2, 3));
+      [always, onCreate, none].forEach(({ system }) => step(system));
+
+      assert.closeTo(a.instance.rotation.z, 3, 1e-9, 'always follows');
+      assert.equal(o.instance.rotation.z, 0, 'onCreate kept its 0 snapshot');
+      assert.equal(n.instance.rotation.z, 0, 'none ignores');
+    });
+  });
+
+  describe('scale', () => {
+    it('always: bakes the current parent scale into new child radii', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'always' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      instance.particles.forEach(p =>
+        assert.closeTo(p.radius, 10, 1e-6, 'parent scale 1 → radius unchanged')
+      );
+
+      particle.scale = 4;
+      step(system, 3);
+
+      const scaled = instance.particles.filter(p => p.radius > 30);
+
+      assert.isAbove(scaled.length, 0, 'new child particles grew with parent');
+    });
+
+    it('onCreate: snapshots the parent scale, ignoring later changes', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'onCreate' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      particle.scale = 4;
+      step(system, 3);
+
+      instance.particles.forEach(p =>
+        assert.closeTo(p.radius, 10, 1e-6, 'radius fixed at the spawn snapshot')
+      );
+    });
+
+    it('none: parent scale never touches child radius', () => {
+      const { system, parent } = build({
+        inherit: { scale: 'none' },
+        childRadius: 10,
+      });
+
+      step(system);
+      const { particle, instance } = soleInstance(parent);
+
+      particle.scale = 9;
+      step(system, 3);
+
+      instance.particles.forEach(p => assert.closeTo(p.radius, 10, 1e-6));
+    });
+  });
+
+  it('acceptance: flipping position always→onCreate turns an attached trail into a left-behind band', () => {
+    // Same system, one knob. `always` keeps the child pinned to the moving
+    // parent; `onCreate` leaves it where the parent was at spawn.
+    const attached = build({ inherit: { position: 'always' }, parentX: 5 });
+    const band = build({ inherit: { position: 'onCreate' }, parentX: 5 });
+
+    step(attached.system);
+    step(band.system);
+
+    const a = soleInstance(attached.parent);
+    const b = soleInstance(band.parent);
+
+    a.particle.position.set(200, 0, 0);
+    b.particle.position.set(200, 0, 0);
+    step(attached.system);
+    step(band.system);
+
+    assert.closeTo(a.instance.position.x, 200, 1e-9, 'attached: rides along');
+    assert.closeTo(b.instance.position.x, 5, 1e-9, 'band: stays behind');
+  });
+});


### PR DESCRIPTION
Recreates the Stage 3 PR. The original **#322** was auto-closed by GitHub when its base branch (`feat/emitter-hierarchy-tree`) was deleted during the #321 merge — GitHub closed the dependent PR instead of retargeting it. Same branch (`feat/emitter-hierarchy-inheritance`), same commits; only the base changed to the integration branch.

Completes the `inherit` config: `position`/`rotation`/`scale` × `always`/`onCreate`/`none`. Scale is baked into particle `radius` at birth (Scale behaviours overwrite `scale`). See #322 for the original discussion.