### PR TITLE
feat(ribbon): default soft edge + tangent smoothing

### DIFF
--- a/src/renderer/RibbonRenderer.ts
+++ b/src/renderer/RibbonRenderer.ts
@@ -32,6 +32,14 @@ interface RibbonRendererOptions {
   texture?: Texture;
   // 'stretch' maps U 0→1 across the whole ribbon; 'tile' repeats U per segment.
   uv: 'stretch' | 'tile';
+  // Fade the strip's opacity across its width (a built-in alphaMap) so an
+  // untextured ribbon reads as a soft streak rather than a hard-edged flat band.
+  // Composes with `texture`. Set false for a hard-edged strip.
+  softEdge: boolean;
+  // Tangent-smoothing window (points each side) when orienting the strip. A wider
+  // window rides over spine noise so a slightly scattered spine doesn't produce a
+  // self-crossing sawtooth. Clamped to >= 1.
+  smoothing: number;
   depthTest: boolean;
   depthWrite: boolean;
 }
@@ -40,6 +48,8 @@ const DEFAULT_OPTIONS: RibbonRendererOptions = {
   width: 20,
   blending: 'AdditiveBlending',
   uv: 'stretch',
+  softEdge: true,
+  smoothing: 2,
   depthTest: true,
   depthWrite: false,
 };
@@ -103,6 +113,8 @@ export default class RibbonRenderer extends BaseRenderer {
   _side: Vector3;
   _lastSide: Vector3;
   _up: Vector3;
+  // Built-in across-width opacity falloff shared by every ribbon (see softEdge).
+  _softEdgeMap: Texture | null;
 
   constructor(
     container: Object3D,
@@ -124,6 +136,30 @@ export default class RibbonRenderer extends BaseRenderer {
     this._side = new THREE.Vector3();
     this._lastSide = new THREE.Vector3(1, 0, 0);
     this._up = new THREE.Vector3(0, 1, 0);
+    this._softEdgeMap = this.options.softEdge ? this._makeSoftEdgeMap() : null;
+  }
+
+  // A 1×N alpha ramp — transparent at the strip edges (V 0 and 1), opaque down
+  // the centre line — applied as the material's alphaMap so the width fades
+  // smoothly. Built from a data array (no DOM), so it works headless/in tests.
+  _makeSoftEdgeMap(): Texture {
+    const n = 64;
+    const data = new Uint8Array(n * 4);
+
+    for (let i = 0; i < n; i++) {
+      const a = Math.round(Math.sin((i / (n - 1)) * Math.PI) * 255);
+
+      data[i * 4] = a;
+      data[i * 4 + 1] = a;
+      data[i * 4 + 2] = a;
+      data[i * 4 + 3] = 255;
+    }
+
+    const texture = new this.three.DataTexture(data, 1, n);
+
+    texture.needsUpdate = true;
+
+    return texture;
   }
 
   // Group key: the emitting instance, falling back to the node id or a shared
@@ -195,12 +231,13 @@ export default class RibbonRenderer extends BaseRenderer {
       const particle = group[i];
       const point = particle.position as unknown as Vector3;
 
-      // Tangent by central difference (forward/backward at the ends).
-      this._prev.copy(
-        i > 0 ? (group[i - 1].position as unknown as Vector3) : point
-      );
+      // Tangent by central difference over a smoothing window (clamped at the
+      // ends), so a slightly noisy spine doesn't jitter the strip's orientation.
+      const w = Math.max(1, this.options.smoothing);
+
+      this._prev.copy(group[Math.max(0, i - w)].position as unknown as Vector3);
       this._next.copy(
-        i < n - 1 ? (group[i + 1].position as unknown as Vector3) : point
+        group[Math.min(n - 1, i + w)].position as unknown as Vector3
       );
       this._tangent.subVectors(this._next, this._prev);
 
@@ -318,6 +355,7 @@ export default class RibbonRenderer extends BaseRenderer {
         side: THREE.DoubleSide,
         blending: THREE[blending],
         map: texture || null,
+        alphaMap: this._softEdgeMap,
         depthTest,
         depthWrite,
       });
@@ -356,6 +394,11 @@ export default class RibbonRenderer extends BaseRenderer {
   remove(_system?: System): void {
     this._ribbons.forEach((_ribbon, key) => this._disposeRibbon(key));
     this._groups.clear();
+
+    if (this._softEdgeMap) {
+      this._softEdgeMap.dispose();
+      this._softEdgeMap = null;
+    }
   }
 
   destroy(): void {

--- a/test/renderer/RibbonRenderer.spec.js
+++ b/test/renderer/RibbonRenderer.spec.js
@@ -156,3 +156,52 @@ describe('renderer -> RibbonRenderer -> rebuild', () => {
     assert.equal(r._ribbons.get('a').geometry.drawRange.count, 11 * 6);
   });
 });
+
+describe('renderer -> RibbonRenderer -> soft edge & smoothing', () => {
+  const build = (opts = {}) => {
+    const r = new RibbonRenderer(new THREE.Object3D(), THREE, opts);
+
+    for (let i = 0; i < 4; i++) {
+      r.onParticleCreated(
+        particle({ instance: 'a', spawnIndex: i, x: i * 10 })
+      );
+    }
+    r.onSystemUpdate();
+
+    return r;
+  };
+
+  it('applies a built-in soft-edge alphaMap by default', () => {
+    const r = build();
+
+    assert.isNotNull(r._softEdgeMap, 'soft-edge map created');
+    assert.strictEqual(
+      r._ribbons.get('a').mesh.material.alphaMap,
+      r._softEdgeMap,
+      'material uses the shared soft-edge map'
+    );
+  });
+
+  it('omits the soft edge when softEdge is false', () => {
+    const r = build({ softEdge: false });
+
+    assert.isNull(r._softEdgeMap);
+    assert.isNull(r._ribbons.get('a').mesh.material.alphaMap);
+  });
+
+  it('disposes the soft-edge map on remove', () => {
+    const r = build();
+
+    r.remove();
+    assert.isNull(r._softEdgeMap);
+  });
+
+  it('produces a finite strip with a wider smoothing window', () => {
+    const r = build({ smoothing: 3 });
+    const pos = r._ribbons.get('a').geometry.attributes.position.array;
+
+    for (let i = 0; i < 4 * 6; i++) {
+      assert.isFalse(Number.isNaN(pos[i]));
+    }
+  });
+});


### PR DESCRIPTION
Polish for the `RibbonRenderer` (shipped in 13.1.0). Both fixes address a poor out-of-box experience found while building spell VFX: an **untextured** ribbon rendered as hard flat strips, and a slightly noisy spine self-crossed into a sawtooth.

## Changes

- **`softEdge` (default `true`)** — a built-in across-width opacity falloff, applied as the material's `alphaMap` (a 1×N `DataTexture` built from a data array, so it works headless / in tests — no DOM). An untextured ribbon now reads as a soft glowing streak instead of a hard-edged band. It **composes with a user `texture`** (the texture drives colour/detail, the alphaMap softens the width edges). Pass `softEdge: false` for a hard strip. The shared map is disposed on `remove`.
- **`smoothing` (default `2`)** — the orientation tangent is taken over a window of N points each side (clamped at the ends), so the strip rides over spine noise rather than jittering per-segment.

## Why

Three separate "the ribbon looks like flat white squares" reports during VFX work all turned out to be *usage* traps (no texture → hard edges; a scattered spine → sawtooth). Sharpening the defaults so the first-run result looks like a ribbon.

## Tests / verification

`RibbonRenderer.spec` gains coverage for the alphaMap default, the `softEdge:false` opt-out, disposal, and the smoothing window. Full suite **324 pass**; tsc/lint/format/madge clean. Visually confirmed on the untextured `ribbon-trails` demo — it now renders soft-edged streaks with no texture passed.

## Notes

- Additive/backward-compatible (new opt-in options with sensible defaults). The default `softEdge` slightly changes the look of an existing untextured ribbon (softer edges) — an improvement, not a break.
- No VR baseline uses the RibbonRenderer, so no baselines shift.