### PR TITLE
feat(behaviour): first-class Vortex behaviour

### DIFF
--- a/sandbox/examples/Vortex/init.js
+++ b/sandbox/examples/Vortex/init.js
@@ -1,0 +1,71 @@
+import ParticleSystem, {
+  Alpha,
+  Body,
+  Color,
+  Emitter,
+  Life,
+  Mass,
+  Position,
+  Radius,
+  Rate,
+  Scale,
+  Span,
+  SphereZone,
+  SpriteRenderer,
+  Vector3D,
+  Vortex,
+} from 'three-nebula';
+
+import dot from '../../assets/dot.png';
+
+// Vortex behaviour — energy spawns across a sphere and is swirled around the
+// view axis with an inward pull, spiralling toward the centre as it converges.
+// Uses SpriteRenderer so the VR golden master (SwiftShader) renders faithfully.
+
+let THREE;
+
+const CENTER = new Vector3D(0, 0, 0);
+const AXIS = new Vector3D(0, 0, 1); // swirl faces the camera
+
+const createSprite = () => {
+  const material = new THREE.SpriteMaterial({
+    map: new THREE.TextureLoader().load(dot),
+    color: 0xffffff,
+    blending: THREE.AdditiveBlending,
+    fog: true,
+  });
+
+  return new THREE.Sprite(material);
+};
+
+const createEmitter = () =>
+  new Emitter()
+    .setRate(new Rate(new Span(8, 12), new Span(0.01, 0.02)))
+    .addInitializers([
+      new Body(createSprite()),
+      new Mass(1),
+      new Life(2, 3),
+      new Radius(8, 16),
+      new Position(new SphereZone(200)),
+    ])
+    .addBehaviours([
+      // Strong swirl, gentle pull → particles orbit several times as they fall
+      // in, so the spiral reads (not just a churning cloud).
+      new Vortex(CENTER, AXIS, 820, 70),
+      new Color('#8a4dff', '#33ecff'), // violet → arcane cyan as it converges
+      new Alpha(0.9, 0),
+      new Scale(1.2, 0.2),
+    ])
+    .emit();
+
+export default async (three, { scene, camera }) => {
+  THREE = three;
+
+  const system = new ParticleSystem();
+
+  camera.position.z = 500;
+
+  return system
+    .addEmitter(createEmitter())
+    .addRenderer(new SpriteRenderer(scene, THREE));
+};

--- a/sandbox/experiments/arcane-vortex/index.js
+++ b/sandbox/experiments/arcane-vortex/index.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import System, {
   Alpha,
-  Behaviour,
   Body,
   Color,
   Emitter,
@@ -16,49 +15,16 @@ import System, {
   SphereZone,
   GPURenderer,
   Vector3D,
+  Vortex,
 } from 'three-nebula';
 import { run } from '/common/run.js';
 
 // Arcane Vortex — a spell charge-up: energy is drawn inward in a tightening
 // spiral toward the caster's focus, brightening as it converges.
 //
-// Ad-hoc workaround for a real library gap (no curl/vortex force field, filed as
-// specs/curl-noise-force-field.md): a custom Behaviour applying a tangential
-// force around an axis plus an inward pull. Written against particle.velocity, so
-// it is NOT subject to the Force ×100 (MEASURE) scaling — tune in the hundreds.
-
-class Vortex extends Behaviour {
-  constructor(center, axis, swirl = 400, pull = 80, life, easing, isEnabled = true) {
-    super(life, easing, 'Vortex', isEnabled);
-    this.center = center;
-    this.axis = axis.clone().normalize();
-    this.swirl = swirl;
-    this.pull = pull;
-    this._r = new Vector3D();
-    this._t = new Vector3D();
-    this._in = new Vector3D();
-    this._axis = new Vector3D();
-  }
-
-  mutate(particle, time) {
-    this.energize(particle, time);
-
-    // Radial vector from the axis line to the particle (component ⟂ to axis).
-    this._r.copy(particle.position).sub(this.center);
-    const along = this._r.dot(this.axis);
-    this._r.sub(this._axis.copy(this.axis).multiplyScalar(along));
-
-    const dist = this._r.length() || 1e-3;
-
-    // Tangential swirl (axis × radial) + inward pull, tightened toward the core.
-    this._t.copy(this.axis).cross(this._r).multiplyScalar(this.swirl / dist);
-    this._in.copy(this._r).multiplyScalar(-this.pull / dist);
-
-    particle.velocity
-      .add(this._t.multiplyScalar(time))
-      .add(this._in.multiplyScalar(time));
-  }
-}
+// Uses the first-class `Vortex` behaviour (a tangential swirl around an axis plus
+// an optional inward pull). It writes to particle.velocity, so it is NOT subject
+// to the Force ×100 (MEASURE) scaling — tune swirl/pull in the hundreds.
 
 const CENTER = new Vector3D(0, 0, 0);
 const AXIS = new Vector3D(0, 0, 1); // swirl faces the camera

--- a/src/behaviour/Vortex.ts
+++ b/src/behaviour/Vortex.ts
@@ -1,0 +1,199 @@
+import {
+  DEFAULT_BEHAVIOUR_EASING,
+  DEFAULT_LIFE,
+  DEFAULT_VORTEX_FALLOFF,
+  DEFAULT_VORTEX_PULL,
+  DEFAULT_VORTEX_SWIRL,
+  VORTEX_MIN_DISTANCE,
+} from './constants';
+
+import Behaviour from './Behaviour';
+import { Vector3D } from '../math';
+import { getEasingByName } from '../ease';
+import { BEHAVIOUR_TYPE_VORTEX as type } from './types';
+import type { EasingFunction, EaseName } from '../ease';
+import type Particle from '../core/Particle';
+
+interface VortexJSON {
+  x: number;
+  y: number;
+  z: number;
+  axisX: number;
+  axisY: number;
+  axisZ: number;
+  swirl: number;
+  pull: number;
+  falloff: number;
+  life?: number;
+  easing?: EaseName | (string & {});
+  isEnabled?: boolean;
+}
+
+/**
+ * Behaviour that swirls particles around an axis — a coherent tangential flow
+ * field, with an optional inward/outward pull, for vortices, spell charge-ups,
+ * tornados and orbiting motes.
+ *
+ * Unlike the radial point forces (`Attraction`/`Repulsion`), the swirl direction
+ * is the tangent around the axis (`axis × radial`), so particles orbit rather
+ * than converge. The force is applied to the particle's **velocity** (not
+ * acceleration), so it is not subject to the `Force` 1:100 (MEASURE) scaling —
+ * magnitudes are intuitive (tune `swirl`/`pull` in the hundreds). Deterministic
+ * by construction (no randomness).
+ */
+export default class Vortex extends Behaviour {
+  center: Vector3D;
+  axis: Vector3D;
+  swirl: number;
+  pull: number;
+  falloff: number;
+
+  private _radial: Vector3D;
+  private _tangential: Vector3D;
+  private _axisProjection: Vector3D;
+
+  /**
+   * Constructs a Vortex behaviour instance.
+   *
+   * @param center - A point on the swirl axis
+   * @param axis - The axis particles swirl around (normalised internally)
+   * @param swirl - Tangential force scalar (orbit speed)
+   * @param pull - Radial force scalar: inward (+) / outward (−)
+   * @param falloff - Radial falloff exponent; force scales by 1 / dist^falloff
+   * @param life - The life of the behaviour
+   * @param easing - The behaviour's decaying trend
+   * @param isEnabled - Determines if the behaviour will be applied or not
+   */
+  constructor(
+    center: Vector3D = new Vector3D(),
+    axis: Vector3D = new Vector3D(0, 0, 1),
+    swirl: number = DEFAULT_VORTEX_SWIRL,
+    pull: number = DEFAULT_VORTEX_PULL,
+    falloff: number = DEFAULT_VORTEX_FALLOFF,
+    life: number = DEFAULT_LIFE,
+    easing: EasingFunction = DEFAULT_BEHAVIOUR_EASING,
+    isEnabled: boolean = true
+  ) {
+    super(life, easing, type, isEnabled);
+
+    /**
+     * @desc A point on the swirl axis
+     */
+    this.center = center;
+
+    /**
+     * @desc The (normalised) axis particles swirl around
+     */
+    this.axis = axis.clone().normalize();
+
+    /**
+     * @desc The tangential force scalar (orbit speed)
+     */
+    this.swirl = swirl;
+
+    /**
+     * @desc The radial force scalar; inward (+) / outward (−)
+     */
+    this.pull = pull;
+
+    /**
+     * @desc The radial falloff exponent
+     */
+    this.falloff = falloff;
+
+    // Scratch vectors reused each mutate to avoid per-particle allocation.
+    this._radial = new Vector3D();
+    this._tangential = new Vector3D();
+    this._axisProjection = new Vector3D();
+  }
+
+  /**
+   * Resets the behaviour properties.
+   */
+  reset(
+    center: Vector3D = new Vector3D(),
+    axis: Vector3D = new Vector3D(0, 0, 1),
+    swirl: number = DEFAULT_VORTEX_SWIRL,
+    pull: number = DEFAULT_VORTEX_PULL,
+    falloff: number = DEFAULT_VORTEX_FALLOFF,
+    life?: number,
+    easing?: EasingFunction
+  ): void {
+    this.center = center;
+    this.axis = axis.clone().normalize();
+    this.swirl = swirl;
+    this.pull = pull;
+    this.falloff = falloff;
+
+    life && super.reset(life, easing);
+  }
+
+  /**
+   * Mutates the particle's velocity, swirling it around the axis.
+   *
+   * @param particle - the particle to apply the behaviour to
+   * @param time - particle engine time
+   * @param index - the particle index
+   */
+  mutate(particle: Particle, time: number, index?: number): void {
+    this.energize(particle, time, index);
+
+    // Radial vector from the axis line to the particle: the component of
+    // (position - center) perpendicular to the axis.
+    this._radial.copy(particle.position).sub(this.center);
+
+    const along = this._radial.dot(this.axis);
+
+    this._radial.sub(this._axisProjection.copy(this.axis).scalar(along));
+
+    const distance = this._radial.length();
+
+    // On (or too near) the axis there is no well-defined tangent — leave it.
+    if (distance < VORTEX_MIN_DISTANCE) {
+      return;
+    }
+
+    const inverse = 1 / Math.pow(distance, this.falloff);
+
+    // Tangential (axis × radial) drives the orbit; the radial term pulls in
+    // (positive) or pushes out (negative). Both are integrated over time.
+    this._tangential.copy(this.axis).cross(this._radial);
+
+    particle.velocity
+      .addScaledVector(this._tangential, this.swirl * inverse * time)
+      .addScaledVector(this._radial, -this.pull * inverse * time);
+  }
+
+  /**
+   * Creates a Vortex behaviour from JSON.
+   *
+   * @param json - The JSON to construct the instance from.
+   */
+  static fromJSON(json: VortexJSON): Vortex {
+    const {
+      x = 0,
+      y = 0,
+      z = 0,
+      axisX = 0,
+      axisY = 0,
+      axisZ = 1,
+      swirl,
+      pull,
+      falloff,
+      life,
+      easing,
+      isEnabled = true,
+    } = json;
+
+    return new Vortex(
+      new Vector3D(x, y, z),
+      new Vector3D(axisX, axisY, axisZ),
+      swirl,
+      pull,
+      falloff,
+      life,
+      getEasingByName(easing),
+      isEnabled
+    );
+  }
+}

--- a/src/behaviour/constants.ts
+++ b/src/behaviour/constants.ts
@@ -6,6 +6,12 @@ export const DEFAULT_ATTRACTION_FORCE_SCALAR = 100;
 export const DEFAULT_BEHAVIOUR_EASING = easeLinear;
 export const DEFAULT_BEHAVIOUR_EASING_TYPE = 'easeLinear';
 export const DEFAULT_RANDOM_DRIFT_DELAY = 0.03;
+export const DEFAULT_VORTEX_SWIRL = 400;
+export const DEFAULT_VORTEX_PULL = 0;
+export const DEFAULT_VORTEX_FALLOFF = 1;
+// Below this distance from the swirl axis a particle has no well-defined
+// tangent, so the Vortex leaves it untouched (also avoids a 1/dist^falloff blowup).
+export const VORTEX_MIN_DISTANCE = 0.0001;
 export const PARTICLE_ALPHA_THRESHOLD = 0.002;
 export const PARTICLE_LENGTH_SQ_THRESHOLD = 0.000004;
 export const DEFAULT_CROSS_TYPE = 'dead';

--- a/src/behaviour/index.ts
+++ b/src/behaviour/index.ts
@@ -10,4 +10,5 @@ export { default as Repulsion } from './Repulsion';
 export { default as Rotate } from './Rotate';
 export { default as Scale } from './Scale';
 export { default as Spring } from './Spring';
+export { default as Vortex } from './Vortex';
 export { default as Behaviour } from './Behaviour';

--- a/src/behaviour/types.ts
+++ b/src/behaviour/types.ts
@@ -11,3 +11,4 @@ export const BEHAVIOUR_TYPE_REPULSION = 'Repulsion';
 export const BEHAVIOUR_TYPE_ROTATE = 'Rotate';
 export const BEHAVIOUR_TYPE_SCALE = 'Scale';
 export const BEHAVIOUR_TYPE_SPRING = 'Spring';
+export const BEHAVIOUR_TYPE_VORTEX = 'Vortex';

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -10,6 +10,7 @@ import {
   BEHAVIOUR_TYPE_ROTATE,
   BEHAVIOUR_TYPE_SCALE,
   BEHAVIOUR_TYPE_SPRING,
+  BEHAVIOUR_TYPE_VORTEX,
 } from '../behaviour/types';
 import {
   INITIALIZER_TYPE_BODY,
@@ -186,6 +187,7 @@ export const SUPPORTED_JSON_BEHAVIOUR_TYPES = [
   BEHAVIOUR_TYPE_ROTATE,
   BEHAVIOUR_TYPE_SCALE,
   BEHAVIOUR_TYPE_SPRING,
+  BEHAVIOUR_TYPE_VORTEX,
 ] as const;
 
 /** The behaviour `type` strings accepted by `System.fromJSON`. */

--- a/src/core/fromJSON.ts
+++ b/src/core/fromJSON.ts
@@ -62,6 +62,7 @@ const BEHAVIOURS = {
   Rotate: Behaviour.Rotate,
   Scale: Behaviour.Scale,
   Spring: Behaviour.Spring,
+  Vortex: Behaviour.Vortex,
 } satisfies Record<SupportedBehaviourType, BehaviourFactory>;
 
 // The concrete `fromJSON` methods each take a narrow `*JSON` param; the JSON we

--- a/test/behaviour/Vortex.spec.js
+++ b/test/behaviour/Vortex.spec.js
@@ -1,0 +1,169 @@
+import * as Nebula from '../../src';
+
+import { TIME } from '../constants';
+import chai from 'chai';
+
+const { assert } = chai;
+
+describe('behaviour -> Vortex', () => {
+  it('should instantiate with the correct properties', () => {
+    const behaviour = new Nebula.Vortex();
+    const {
+      type,
+      life,
+      easing,
+      age,
+      energy,
+      dead,
+      center,
+      axis,
+      swirl,
+      pull,
+      falloff,
+      isEnabled,
+    } = behaviour;
+
+    assert.equal(type, 'Vortex');
+    assert.strictEqual(life, Infinity);
+    assert.isFunction(easing);
+    assert.strictEqual(age, 0);
+    assert.strictEqual(energy, 1);
+    assert.isFalse(dead);
+    assert.isTrue(center instanceof Nebula.Vector3D);
+    assert.isTrue(axis instanceof Nebula.Vector3D);
+    assert.deepEqual(Object.values(axis), [0, 0, 1]);
+    assert.strictEqual(swirl, 400);
+    assert.strictEqual(pull, 0);
+    assert.strictEqual(falloff, 1);
+    assert.isTrue(isEnabled);
+  });
+
+  it('should normalise the axis on construction', () => {
+    const behaviour = new Nebula.Vortex(
+      new Nebula.Vector3D(),
+      new Nebula.Vector3D(0, 0, 2)
+    );
+
+    assert.deepEqual(Object.values(behaviour.axis), [0, 0, 1]);
+  });
+
+  it('should add a tangential swirl to the particle velocity', () => {
+    // Default: center origin, axis +Z, swirl 400, pull 0, falloff 1.
+    const behaviour = new Nebula.Vortex();
+    const particle = new Nebula.Particle();
+
+    particle.position.set(10, 0, 0);
+    behaviour.applyBehaviour(particle, TIME);
+
+    // tangential = axis × radial = (0,0,1) × (10,0,0) = (0,10,0)
+    // scale       = swirl / dist^falloff * time = 400 / 10 * 1000 = 40000
+    // velocity   += (0,10,0) * 40000 = (0, 400000, 0)
+    assert.deepEqual(Object.values(particle.velocity), [0, 400000, 0]);
+  });
+
+  it('should pull inward toward the axis when pull is positive', () => {
+    const behaviour = new Nebula.Vortex(
+      new Nebula.Vector3D(),
+      new Nebula.Vector3D(0, 0, 1),
+      0, // no swirl, isolate the pull term
+      400
+    );
+    const particle = new Nebula.Particle();
+
+    particle.position.set(10, 0, 0);
+    behaviour.applyBehaviour(particle, TIME);
+
+    // radial term = -pull / dist * time * radial = -400/10*1000 * (10,0,0)
+    //             = (-400000, 0, 0) — toward the axis
+    assert.deepEqual(Object.values(particle.velocity), [-400000, 0, 0]);
+  });
+
+  it('should scale the force by 1 / dist^falloff', () => {
+    const behaviour = new Nebula.Vortex(
+      new Nebula.Vector3D(),
+      new Nebula.Vector3D(0, 0, 1),
+      400,
+      0,
+      2 // falloff = 2
+    );
+    const particle = new Nebula.Particle();
+
+    particle.position.set(10, 0, 0);
+    behaviour.applyBehaviour(particle, TIME);
+
+    // scale = 400 / 10^2 * 1000 = 4000 → (0,10,0) * 4000 = (0, 40000, 0)
+    // i.e. 10× weaker than falloff 1 at the same distance.
+    assert.deepEqual(Object.values(particle.velocity), [0, 40000, 0]);
+  });
+
+  it('should leave particles on the axis untouched', () => {
+    const behaviour = new Nebula.Vortex();
+    const particle = new Nebula.Particle();
+
+    // On the +Z axis: radial component is zero, no defined tangent.
+    particle.position.set(0, 0, 5);
+    behaviour.applyBehaviour(particle, TIME);
+
+    assert.deepEqual(Object.values(particle.velocity), [0, 0, 0]);
+  });
+
+  it('should be deterministic — identical inputs give identical output', () => {
+    const a = new Nebula.Vortex();
+    const b = new Nebula.Vortex();
+    const pa = new Nebula.Particle();
+    const pb = new Nebula.Particle();
+
+    pa.position.set(7, -3, 2);
+    pb.position.set(7, -3, 2);
+
+    a.applyBehaviour(pa, TIME);
+    b.applyBehaviour(pb, TIME);
+
+    assert.deepEqual(Object.values(pa.velocity), Object.values(pb.velocity));
+  });
+
+  it('should reset the behaviour properties', () => {
+    const behaviour = new Nebula.Vortex();
+
+    behaviour.reset(
+      new Nebula.Vector3D(1, 2, 3),
+      new Nebula.Vector3D(0, 2, 0),
+      500,
+      60,
+      2,
+      3
+    );
+
+    assert.deepEqual(Object.values(behaviour.center), [1, 2, 3]);
+    assert.deepEqual(Object.values(behaviour.axis), [0, 1, 0]);
+    assert.strictEqual(behaviour.swirl, 500);
+    assert.strictEqual(behaviour.pull, 60);
+    assert.strictEqual(behaviour.falloff, 2);
+    assert.strictEqual(behaviour.life, 3);
+  });
+
+  it('should construct the behaviour from a JSON object', () => {
+    const instance = Nebula.Vortex.fromJSON({
+      x: 1,
+      y: 2,
+      z: 3,
+      axisX: 0,
+      axisY: 1,
+      axisZ: 0,
+      swirl: 500,
+      pull: 60,
+      falloff: 2,
+      life: 3,
+      easing: 'easeInOutExpo',
+    });
+
+    assert.instanceOf(instance, Nebula.Vortex);
+    assert.deepEqual(Object.values(instance.center), [1, 2, 3]);
+    assert.deepEqual(Object.values(instance.axis), [0, 1, 0]);
+    assert.strictEqual(instance.swirl, 500);
+    assert.strictEqual(instance.pull, 60);
+    assert.strictEqual(instance.falloff, 2);
+    assert.strictEqual(instance.life, 3);
+    assert.isTrue(instance.isEnabled);
+  });
+});

--- a/vr/baselines/Vortex.png
+++ b/vr/baselines/Vortex.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:245f27ba35bf88c3c7f80c794d43a288640301e55919447812c32ace141c6fbb
+size 98513

--- a/vr/examples.js
+++ b/vr/examples.js
@@ -7,6 +7,8 @@
 // golden master until modernised.
 export const EXAMPLES = {
   SpriteRendererGravity: { kind: 'init', frames: 120 },
+  // The Vortex behaviour — a swirling inflow (SpriteRenderer for SwiftShader).
+  Vortex: { kind: 'init', frames: 120 },
   SpriteRendererPointZone: { kind: 'init', frames: 120 },
   CustomRenderer: { kind: 'init', frames: 120 },
   EightDiagrams: { kind: 'init', frames: 120 },


### PR DESCRIPTION
## Summary

Adds a first-class **`Vortex`** behaviour — a coherent tangential swirl around an axis, the ship-first tier of `specs/curl-noise-force-field.md`. This fills the biggest gap for organic motion: three-nebula's force vocabulary was radial point forces (`Attraction`/`Repulsion`/`Spring`), constants (`Force`/`Gravity`) and random jitter (`RandomDrift`) — there was no coherent flow field, so vortices/charge-ups/orbits all read as "drift + radial pull". `Vortex` makes particles *orbit*.

The `CurlNoise` tier (seeded procedural turbulence) is a deliberate follow-up on its own branch.

## What ships (`src/` — published)

- **`src/behaviour/Vortex.ts`** — `new Vortex(center, axis, swirl, pull, falloff, life, easing, isEnabled)`:
  - tangential force `axis × radial` (the swirl), scaled by `swirl / dist^falloff`
  - optional `pull`: inward (+) / outward (−) radial force
  - applied to **`particle.velocity`**, not acceleration → NOT subject to the `Force` 1:100 (MEASURE) scaling, so magnitudes are intuitive (tune in the hundreds)
  - **deterministic by construction** (no randomness); leaves on-axis particles untouched (no defined tangent)
  - reuses scratch vectors (no per-particle allocation)
- Registered like every other behaviour: type constant, export, defaults, and JSON round-trip (`SUPPORTED_JSON_BEHAVIOUR_TYPES` + `fromJSON` map, `satisfies` check passes).

## Tests

- **`test/behaviour/Vortex.spec.js`** — 9 cases: construction/defaults, axis normalisation, tangential swirl direction, inward pull, `1/dist^falloff` scaling, on-axis no-op, determinism, reset, `fromJSON` round-trip.
- Full suite green (334 tests), `tsc --noEmit` clean, prettier clean.

## Sandbox + VR

- **`arcane-vortex` experiment** now uses the library `Vortex`; the custom `Behaviour` subclass is removed. Behaviour-preserving (same swirl + inward pull).
- **New VR case** `sandbox/examples/Vortex/init.js` (SpriteRenderer, so the SwiftShader golden master renders faithfully — GPURenderer would be blocky), registered in `vr/examples.js`, with a committed LFS baseline `vr/baselines/Vortex.png`. `npm run vr` passes determinism; no other baseline drifted.

## Release note

Additive minor on merge to `develop` — new opt-in behaviour, no breaking changes.
